### PR TITLE
Fix spelling errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Investigate if its possible to get Uponor Clean 1 into Home Assistant
 | OC6      | Mosfet      | 1435 814 |
 
 ## I2C Memory (128-Kbit alias 16kb)
-Extrated with help of a raspberry pi and i2c-tools, Memory exist at adresss 0X50 as can be seen from below. 
+Extracted with help of a raspberry pi and i2c-tools, Memory exist at address 0X50 as can be seen from below. 
 
 Note! I think one need to desolder the memory chips as there was different results.   
 ```


### PR DESCRIPTION
## Summary
- Fix typos in the I2C Memory section of the README: "Extrated" → "Extracted" and "adresss" → "address"

## Test plan
- [x] No functional changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)