### PR TITLE
Document dead serial/modem port attempt (Path A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Investigate if its possible to get Uponor Clean 1 into Home Assistant
 
 ![PCB with text](uclean1.png)
 
+## Modem port / serial (Path A)
+Attempted to read the modem port directly with a laptop and a USB-to-serial cable, sweeping the common baud rates. No traffic was observed on any of them — the port appeared dead. This avenue is parked for now in favour of the flash/firmware work below (Path B).
+
 ## Datasheets 
 | No       | Description | IC           |
 | ---      | ---         |---           |


### PR DESCRIPTION
## Summary
- Record that reading the modem port via a laptop + USB-to-serial cable produced no traffic across the common baud rates, so Path A (direct serial tap) is parked in favour of the firmware/flash work (Path B)

## Test plan
- [x] Documentation only; no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)