### PR TITLE
Add reproducible Ghidra analysis tooling

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -6,7 +6,7 @@ mostly-independent streams; each can be worked in its own branch/worktree.
 | Stream | Goal | Status |
 | ---    | ---  | ---    |
 | Serial (Path A) | Tap the modem port | **Dead** — no traffic at common baud rates |
-| Radio / SPI | Extract the nRF905 config from firmware → native nRF905 receiver | In progress |
+| Radio / SPI | Recover the nRF905 config → native nRF905 receiver | **Not in this firmware** — see below; needs SDR or an nRF9E5 dump |
 | EEPROM | Map the live records the firmware reads from U3 | Blocked on a full 16 KB dump |
 | rtl_433 | FSK decoder for the 868.35 MHz link → MQTT → Home Assistant | Not started |
 
@@ -27,9 +27,14 @@ vectors `0xFFD0-0xFFFF`, reset entry `0x807F`. ~267 functions recovered.
 ## Findings so far
 
 ### Drivers
-- **SPI → nRF9E5 radio:** byte-shift primitive ~`0xBD56`; `SPI1D` writes at
-  `0xBD5B-0xBDB1`. The nRF905 `W_CONFIG` payload (channel/address/CRC) is set up
-  here. Needs GUI stack-frame cleanup to read cleanly.
+- **SPI → nRF9E5 radio (slave side):** `0xBD56` is the SPI **receive interrupt
+  handler** (vector `0xFFE0` = `BD 56`), not a config routine. Peripheral init
+  writes `MOV #$CC,$28` → `SPI1C1=0xCC`, i.e. `MSTR=0`: the MC9S08 is the SPI
+  **slave**. The nRF9E5's embedded 8051 is the SPI master and owns the nRF905
+  `W_CONFIG` (channel/address/CRC). That config is therefore **not present in
+  `clean1.s19`** — it must come from an SDR capture or a dump of the nRF9E5's
+  internal program memory. The `SPI1D` accesses at `0xBD5B-0xBDB1` are the
+  slave's byte handling, not config setup.
 - **I2C → M24128 (U3):** bus driver `0xDED1-0xE03A`. `FUN_ded1` = start+send byte,
   `FUN_dfd2` = read byte, `FUN_df6a` = stop, `FUN_a554(buf, _, len, addrHi, addrLo)`
   = sequential read of `len` bytes from a 16-bit word address. Length-typed

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,44 @@
+# Analysis notes
+
+Working notes for the reverse-engineering effort. The high-level plan has four
+mostly-independent streams; each can be worked in its own branch/worktree.
+
+| Stream | Goal | Status |
+| ---    | ---  | ---    |
+| Serial (Path A) | Tap the modem port | **Dead** — no traffic at common baud rates |
+| Radio / SPI | Extract the nRF905 config from firmware → native nRF905 receiver | In progress |
+| EEPROM | Map the live records the firmware reads from U3 | Blocked on a full 16 KB dump |
+| rtl_433 | FSK decoder for the 868.35 MHz link → MQTT → Home Assistant | Not started |
+
+## Reproducing the firmware analysis
+
+```
+tools/analyze.sh DumpReport.java                       # function map + SPI/IIC accesses
+tools/analyze.sh DecompileCallers.java /tmp/out.txt a554 ded1   # follow a primitive outward
+```
+
+`analyze.sh` imports `clean1.s19` with `MotorolaHexLoader` and language
+`HCS08:BE:16:MC9S08GB60`, in a throwaway project. Set `GHIDRA_HOME` if Ghidra is
+not under `/opt/ghidra`.
+
+Image layout: sparse — config bytes at `0x107F`/`0x1800`, code `0x8000-0xFFFF`,
+vectors `0xFFD0-0xFFFF`, reset entry `0x807F`. ~267 functions recovered.
+
+## Findings so far
+
+### Drivers
+- **SPI → nRF9E5 radio:** byte-shift primitive ~`0xBD56`; `SPI1D` writes at
+  `0xBD5B-0xBDB1`. The nRF905 `W_CONFIG` payload (channel/address/CRC) is set up
+  here. Needs GUI stack-frame cleanup to read cleanly.
+- **I2C → M24128 (U3):** bus driver `0xDED1-0xE03A`. `FUN_ded1` = start+send byte,
+  `FUN_dfd2` = read byte, `FUN_df6a` = stop, `FUN_a554(buf, _, len, addrHi, addrLo)`
+  = sequential read of `len` bytes from a 16-bit word address. Length-typed
+  wrappers exist for 1/2/4/5/16/23/25-byte reads.
+- **Peripheral init:** `0xFE80` (sets `SPI1C1/C2/BR`, `IIC1A/IIC1F`), runs from reset.
+
+### EEPROM (U3) map
+The firmware reads/writes records near the **top** of the chip — e.g. `0x3A9D`
+(5-byte record), `0x3AD5` (2-byte), plus stride-8 indexed record arrays. The
+README `i2cdump` only captured page 0 (`0x00-0xFF`) and used single-byte
+addressing, so it **misses** the active region. Use `tools/dump_eeprom.sh` on the
+Pi to get the full 16 KB (`0x3A00-0x3FFF` is the interesting part).

--- a/tools/analyze.sh
+++ b/tools/analyze.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Headless Ghidra analysis of the MC9S08GT (HCS08) flash dump.
+# Imports clean1.s19 with the correct loader/processor, runs a script, throws
+# the project away afterwards so runs are reproducible and stateless.
+#
+# Usage: tools/analyze.sh <ScriptName.java> [script args...]
+#   GHIDRA_HOME overrides the Ghidra install location (default /opt/ghidra).
+set -euo pipefail
+
+GHIDRA="${GHIDRA_HOME:-/opt/ghidra}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${1:?usage: analyze.sh <ScriptName.java> [args...]}"
+shift
+
+if [[ ! -x "$GHIDRA/support/analyzeHeadless" ]]; then
+  echo "analyzeHeadless not found under $GHIDRA (set GHIDRA_HOME)" >&2
+  exit 1
+fi
+
+PROJDIR="$(mktemp -d)"
+trap 'rm -rf "$PROJDIR"' EXIT
+
+"$GHIDRA/support/analyzeHeadless" "$PROJDIR" proj \
+  -import "$REPO/clean1.s19" \
+  -loader MotorolaHexLoader \
+  -processor "HCS08:BE:16:MC9S08GB60" \
+  -scriptPath "$REPO/tools/ghidra" \
+  -postScript "$SCRIPT" "$@" \
+  -deleteProject

--- a/tools/dump_eeprom.sh
+++ b/tools/dump_eeprom.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Dump the full 16 KB M24128 EEPROM (U3) over I2C, with correct 2-byte
+# addressing. Run this ON THE RASPBERRY PI (or whatever hosts the I2C bus).
+#
+# i2cdump CANNOT do this: it only reaches offset 0x00-0xFF and sends a single
+# address byte, but the M24128 needs a 14-bit (2-byte) address. The firmware's
+# live records live near 0x3A00-0x3FFF, well outside i2cdump's reach.
+#
+# Usage: tools/dump_eeprom.sh [bus] [outfile]
+#   bus     I2C bus number (default 1)
+#   outfile output path (default clean1_eeprom.bin)
+#
+# Prefer the kernel at24 driver when available (gives a clean binary); fall
+# back to i2ctransfer chunked reads otherwise.
+set -euo pipefail
+
+BUS="${1:-1}"
+OUT="${2:-clean1_eeprom.bin}"
+ADDR="0x50"
+SIZE=16384          # 128 Kbit = 16 KB
+CHUNK=128           # bytes per i2ctransfer read
+
+sysfs="/sys/bus/i2c/devices/${BUS}-00$(printf '%02x' "$ADDR" 2>/dev/null || echo 50)/eeprom"
+
+if command -v modprobe >/dev/null && [[ -e /sys/bus/i2c/devices/i2c-${BUS}/new_device ]]; then
+  echo "Trying kernel at24 driver..." >&2
+  sudo modprobe at24 || true
+  if [[ ! -e "$sysfs" ]]; then
+    echo "24c128 $ADDR" | sudo tee "/sys/bus/i2c/devices/i2c-${BUS}/new_device" >/dev/null || true
+  fi
+  if [[ -e "$sysfs" ]]; then
+    sudo cp "$sysfs" "$OUT"
+    echo "Wrote $OUT ($(wc -c <"$OUT") bytes) via at24" >&2
+    exit 0
+  fi
+  echo "at24 path unavailable, falling back to i2ctransfer" >&2
+fi
+
+# Fallback: chunked random reads with 2-byte addressing.
+: >"$OUT"
+for (( off=0; off<SIZE; off+=CHUNK )); do
+  hi=$(printf '0x%02x' $(( (off >> 8) & 0xff )))
+  lo=$(printf '0x%02x' $(( off & 0xff )))
+  i2ctransfer -y "$BUS" "w2@${ADDR}" "$hi" "$lo" "r${CHUNK}" \
+    | tr ' ' '\n' | grep -E '^0x' \
+    | while read -r b; do printf '%b' "\\x${b#0x}"; done >>"$OUT"
+done
+echo "Wrote $OUT ($(wc -c <"$OUT") bytes) via i2ctransfer" >&2

--- a/tools/ghidra/DecompileCallers.java
+++ b/tools/ghidra/DecompileCallers.java
@@ -1,0 +1,55 @@
+// Decompile the functions containing the given addresses, plus their direct
+// callers, and write the C to a file. Useful for following a driver primitive
+// outward to the code that supplies its arguments.
+//
+// Run via: tools/analyze.sh DecompileCallers.java <outfile> <hexaddr> [<hexaddr>...]
+//   e.g.   tools/analyze.sh DecompileCallers.java /tmp/eeprom.txt a554 ded1
+import ghidra.app.script.GhidraScript;
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
+import java.io.PrintWriter;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class DecompileCallers extends GhidraScript {
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) {
+            println("usage: DecompileCallers.java <outfile> <hexaddr> [<hexaddr>...]");
+            return;
+        }
+        PrintWriter out = new PrintWriter(args[0]);
+
+        Set<Function> targets = new LinkedHashSet<Function>();
+        for (int i = 1; i < args.length; i++) {
+            long off = Long.parseLong(args[i].replaceFirst("^0x", ""), 16);
+            Function f = getFunctionContaining(toAddr(off));
+            if (f == null) {
+                out.println("(no function at 0x" + Long.toHexString(off) + ")");
+                continue;
+            }
+            targets.add(f);
+            for (ReferenceIterator it = currentProgram.getReferenceManager()
+                    .getReferencesTo(f.getEntryPoint()); it.hasNext();) {
+                Reference r = it.next();
+                Function c = getFunctionContaining(r.getFromAddress());
+                if (c != null) targets.add(c);
+            }
+        }
+
+        DecompInterface di = new DecompInterface();
+        di.openProgram(currentProgram);
+        for (Function f : targets) {
+            out.println("########## " + f.getName() + " @ " + f.getEntryPoint() + " ##########");
+            DecompileResults res = di.decompileFunction(f, 60, monitor);
+            out.println((res != null && res.getDecompiledFunction() != null)
+                    ? res.getDecompiledFunction().getC() : "<decompile failed>");
+            out.println();
+        }
+        out.close();
+        println("wrote " + args[0] + " with " + targets.size() + " functions");
+    }
+}

--- a/tools/ghidra/DumpReport.java
+++ b/tools/ghidra/DumpReport.java
@@ -1,0 +1,47 @@
+// Headless report for the UClean1 MC9S08GT flash.
+// Prints the recovered function list and every access to the SPI / IIC
+// peripheral registers (one line each, safe for log capture).
+//
+// Run via: tools/analyze.sh DumpReport.java
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionIterator;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
+import ghidra.program.model.symbol.ReferenceManager;
+
+public class DumpReport extends GhidraScript {
+    public void run() throws Exception {
+        FunctionManager fm = currentProgram.getFunctionManager();
+        println("=== FUNCTIONS ===");
+        int count = 0;
+        for (FunctionIterator it = fm.getFunctions(true); it.hasNext();) {
+            Function f = it.next();
+            println(f.getEntryPoint() + "  " + f.getName() + "  size=" + f.getBody().getNumAddresses());
+            count++;
+        }
+        println("function_count=" + count);
+
+        // MC9S08GB60 direct-page peripheral registers
+        long[] offs = {0x28, 0x29, 0x2a, 0x2b, 0x2d, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d};
+        String[] names = {"SPI1C1", "SPI1C2", "SPI1BR", "SPI1S", "SPI1D",
+                          "IIC1A", "IIC1F", "IIC1C1", "IIC1S", "IIC1D", "IIC1C2"};
+        AddressSpace sp = currentProgram.getAddressFactory().getDefaultAddressSpace();
+        ReferenceManager rm = currentProgram.getReferenceManager();
+        println("=== PERIPHERAL REGISTER ACCESSES ===");
+        for (int i = 0; i < offs.length; i++) {
+            Address a = sp.getAddress(offs[i]);
+            StringBuilder sb = new StringBuilder();
+            int n = 0;
+            for (ReferenceIterator rit = rm.getReferencesTo(a); rit.hasNext();) {
+                Reference r = rit.next();
+                sb.append(r.getFromAddress()).append(" ");
+                n++;
+            }
+            println(names[i] + " (0x" + Long.toHexString(offs[i]) + "): " + n + " refs  " + sb);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `tools/analyze.sh` — headless Ghidra runner that imports `clean1.s19` with `MotorolaHexLoader` + `HCS08:BE:16:MC9S08GB60` in a throwaway project, so any session/agent can reproduce the disassembly
- `tools/ghidra/DumpReport.java` — recovers the function list and SPI/IIC peripheral-register access map
- `tools/ghidra/DecompileCallers.java` — decompiles a function and its callers (follow a driver primitive outward to its arguments)
- `tools/dump_eeprom.sh` — Pi-side full 16 KB M24128 dump with correct 2-byte addressing (at24 driver, i2ctransfer fallback)
- `ANALYSIS.md` — tracks the four workstreams (serial/radio/eeprom/rtl_433) and findings so far

This is the foundation for working the streams in parallel across multiple clients/worktrees.

## Test plan
- [x] `tools/analyze.sh DumpReport.java` reproduces the 267-function map and the SPI1D/IIC1D access locations
- [ ] `tools/dump_eeprom.sh` to be run on the Pi against real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)