### PR TITLE
Split Ghidra firmware analysis into its own doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,4 @@ objcopy --input-target=srec --output-target=binary clean1.s19 clean1.bin
 ```
 
 ## Firmware analysis (Path B)
-The CPU flash was disassembled in [Ghidra](https://ghidra-sre.org/). Import `clean1.s19` directly (the `MotorolaHexLoader` places the bytes at their real addresses) with language `HCS08:BE:16:MC9S08GB60`. The image is sparse: two config bytes at `0x107F`/`0x1800`, main code `0x8000-0xFFFF`, the interrupt vectors at `0xFFD0-0xFFFF`, and the reset vector (`0xFFFE`) points at the entry `0x807F`. Auto-analysis recovers ~267 functions.
-
-Peripheral driver locations:
-* **SPI -> nRF9E5 radio (slave side):** `0xBD56` is the SPI **receive interrupt handler** (vector `0xFFE0` = `BD 56`), and peripheral init writes `SPI1C1=0xCC` (`MSTR=0`) — so the MC9S08 is the SPI **slave**. The nRF9E5's embedded 8051 is the master and owns the nRF905 `W_CONFIG` (channel / address / CRC). That config is therefore **not present in this flash dump**; recovering it needs an SDR capture or a dump of the nRF9E5's internal program memory. The `SPI1D` accesses at `0xBD5B-0xBDB1` are the slave's byte handling, not config setup.
-* **I2C -> M24128 EEPROM (U3):** the bus driver is `0xDED1-0xE03A`. `FUN_ded1` is start + send-byte, `FUN_dfd2` reads a byte, `FUN_df6a` is stop, and `FUN_a554(buf, _, len, addrHi, addrLo)` is a generic sequential read of `len` bytes from a 16-bit word address. There are length-typed wrappers around it (1/2/4/5/16/23/25-byte reads).
-* **Peripheral init:** `0xFE80` configures the SPI (`SPI1C1/C2/BR`) and I2C (`IIC1A/IIC1F`) registers; it runs from reset.
-
-### Where the EEPROM data really lives
-The firmware reads/writes records near the **top** of the M24128, e.g. `0x3A9D` (5-byte record) and `0x3AD5` (2-byte), plus stride-8 indexed record arrays. The `i2cdump` above only captured page 0 (`0x00-0xFF`), so it **misses the active region around `0x3A00-0x3FFF`**. A full 16-Kbit dump of that area is needed to see the live config/telemetry. (`i2cdump` only does single-byte addressing; use a small 2-byte-addressed read loop or the kernel `at24`/`eeprom` driver instead.)
+The U2 CPU flash (`clean1.s19`) was disassembled in [Ghidra](https://ghidra-sre.org/). How the headless analysis was run, the gotchas, the recovered driver map (I2C EEPROM access layer + the SPI-slave finding that rules the radio config out of this dump), and the generated decompiler C now live on their own page: **[docs/ghidra-firmware-analysis.md](docs/ghidra-firmware-analysis.md)**.

--- a/docs/ghidra-firmware-analysis.md
+++ b/docs/ghidra-firmware-analysis.md
@@ -1,0 +1,130 @@
+# Firmware analysis (Path B) — Ghidra
+
+The U2 CPU is a Freescale/NXP **MC9S08GT32** (HCS08 core). Its flash was read
+out with a [USBDM](https://sourceforge.net/projects/usbdm/files/) programmer to
+`clean1.s19`, then disassembled in [Ghidra](https://ghidra-sre.org/). This page
+records exactly how that was done so anyone can reproduce it, and what was
+found. The raw decompiler output for the interesting drivers is checked in under
+[`docs/ghidra/`](ghidra/).
+
+## How the analysis was run
+
+Everything runs **headless** (no GUI) through a small wrapper, so a run is
+reproducible and leaves no project behind. The tooling lives in
+[`tools/`](../tools/) (added in PR #50):
+
+- `tools/analyze.sh` — imports `clean1.s19` and runs a Ghidra script.
+- `tools/ghidra/DumpReport.java` — lists recovered functions + every SPI/IIC
+  register access.
+- `tools/ghidra/DecompileCallers.java` — decompiles the functions containing
+  given addresses **plus their direct callers**, to a file.
+
+### The two settings that matter
+
+1. **Loader = `MotorolaHexLoader`.** The `-loader` argument takes the loader's
+   *class name*, not its display name. `"Motorola Hex"`, `"Binary"`,
+   `"Raw Binary"` are all rejected as invalid; the Intel-Hex auto-loader chokes
+   on the S-records ("line does not start with record mark"). Importing the
+   `.s19` (not the flat `.bin`) lets the loader place bytes at their real
+   addresses.
+2. **Processor = `HCS08:BE:16:MC9S08GB60`.** (The GB60 variant matches the
+   GT32's core/peripherals closely enough for this work.)
+
+The exact command `analyze.sh` issues:
+
+```bash
+"$GHIDRA/support/analyzeHeadless" "$PROJDIR" proj \
+  -import clean1.s19 \
+  -loader MotorolaHexLoader \
+  -processor "HCS08:BE:16:MC9S08GB60" \
+  -scriptPath tools/ghidra \
+  -postScript "$SCRIPT" "$@" \
+  -deleteProject
+```
+
+Set `GHIDRA_HOME` if Ghidra is not under `/opt/ghidra`.
+
+### Commands actually used
+
+```bash
+# Function map + every SPI/IIC peripheral-register access:
+tools/analyze.sh DumpReport.java
+
+# Follow the EEPROM access layer outward (driver + callers) to a file:
+tools/analyze.sh DecompileCallers.java eeprom_i2c.c a554 ded1 dfd2 df6a
+
+# Peripheral init (settles the SPI master/slave question):
+tools/analyze.sh DecompileCallers.java periph_init.c fe80
+```
+
+### Gotchas hit along the way
+
+- **Scripts must be Java, not Python.** This Ghidra build was not started with
+  PyGhidra, so Python post-scripts fail with "Python is not available". The
+  scripts here are `GhidraScript` subclasses.
+- **Write decompiler C to a file, not stdout.** Multi-line `println` output is
+  mangled by Ghidra's per-line log prefixes; `DecompileCallers.java` uses a
+  `PrintWriter` instead.
+- **`0xBD56` does not decompile.** It sits in a code gap and is never turned
+  into a function by auto-analysis, so `DecompileCallers` reports
+  "(no function at 0xbd56)" and forcing disassembly there yields garbage. Its
+  role is established from the vector table + init instead (see below).
+
+## Image layout
+
+The image is sparse:
+
+| Region            | Address range   |
+| ---               | ---             |
+| Config bytes      | `0x107F`, `0x1800` |
+| Main code         | `0x8000–0xFFFF` |
+| Interrupt vectors | `0xFFD0–0xFFFF` |
+| Reset entry       | `0xFFFE` → `0x807F` |
+
+Auto-analysis recovers ~267 functions.
+
+## Findings
+
+### SPI → nRF9E5 radio (the MC9S08 is the *slave*)
+
+`0xBD56` is the **SPI receive interrupt handler** — vector `0xFFE0` holds
+`BD 56`. Peripheral init then writes `SPI1C1 = 0xCC`
+([`docs/ghidra/periph_init.c`](ghidra/periph_init.c), the `SPI1C1 = 0xcc;`
+line), and bit 4 of that value (`MSTR`) is **0** → the MC9S08 is the SPI
+**slave**. So the nRF9E5's embedded 8051 is the SPI master and owns the nRF905
+`W_CONFIG` (channel / address / CRC).
+
+**Consequence:** the radio configuration is **not present in `clean1.s19`**.
+Recovering it needs either an SDR capture of the 868.35 MHz link or a dump of
+the nRF9E5's internal 8051 program memory. The `SPI1D` accesses around
+`0xBD5B–0xBDB1` are the slave's byte handling, not config setup.
+
+### I2C → M24128 (U3) EEPROM access layer
+
+Bus driver region `0xDED1–0xE03A`. Full decompiled C:
+[`docs/ghidra/eeprom_i2c.c`](ghidra/eeprom_i2c.c).
+
+| Function | Role |
+| ---      | ---  |
+| `FUN_ded1` | I2C start + send byte |
+| `FUN_dfd2` | read a byte |
+| `FUN_df6a` | stop |
+| `FUN_a554(buf, _, len, addrHi, addrLo)` | sequential read of `len` bytes from a 16-bit word address |
+
+There are length-typed wrappers around `FUN_a554` — e.g. `FUN_a631` (2 bytes),
+`FUN_a646` (4), `FUN_b596` (5), `FUN_bbe8` (16), `FUN_b5ab` (23), `FUN_b5c0`
+(25) — each visible in the C calling `FUN_a554(..., <len>, ...)`.
+
+### Peripheral init
+
+`FUN_fe80` runs from reset and configures the clock (ICG), ports, SCI, the I2C
+registers (`IIC1A/IIC1F/IIC1C`), and SPI (`SPI1C1/C2/BR`). Full C:
+[`docs/ghidra/periph_init.c`](ghidra/periph_init.c).
+
+### Where the EEPROM data really lives
+
+The firmware reads/writes records near the **top** of the M24128 — e.g. `0x3A9D`
+(5-byte record), `0x3AD5` (2-byte), plus stride-8 indexed record arrays. The
+README `i2cdump` only captured page 0 (`0x00–0xFF`) with single-byte
+addressing, so it **misses the active region around `0x3A00–0x3FFF`**. See
+[docs/u3-eeprom.md](u3-eeprom.md) for the correct full 16 KB dump procedure.

--- a/docs/ghidra/eeprom_i2c.c
+++ b/docs/ghidra/eeprom_i2c.c
@@ -1,0 +1,598 @@
+/*
+ * Ghidra decompiler output — I2C / M24128 (U3) EEPROM access layer.
+ *
+ * Auto-generated, NOT hand-written or compilable. Reproduce with:
+ *   tools/analyze.sh DecompileCallers.java eeprom_i2c.c a554 ded1 dfd2 df6a
+ *
+ * FUN_a554(buf,_,len,addrHi,addrLo) = generic sequential read of `len` bytes
+ * from a 16-bit word address; FUN_ded1 = I2C start + send byte; FUN_dfd2 =
+ * read byte; FUN_df6a = stop. The FUN_a6xx / FUN_b5xx wrappers just call
+ * FUN_a554 with a fixed length (2/4/5/16/23/25). `undefinedN` / `in_stack_*`
+ * artifacts are the decompiler's view of HCS08 stacked args, not real types.
+ */
+
+########## FUN_a554 @ a554 ##########
+
+/* WARNING: Instruction at (RAM,0xa575) overlaps instruction at (RAM,0xa574)
+    */
+
+undefined1 FUN_a554(undefined2 param_1,short param_2)
+
+{
+  byte bVar1;
+  undefined1 *puVar2;
+  char cVar3;
+  undefined1 uVar4;
+  char cVar6;
+  short sVar5;
+  undefined1 in_stack_00000000;
+  char cStack_1;
+  undefined1 *puVar7;
+  
+  cVar6 = (char)param_1;
+  puVar7 = (undefined1 *)CONCAT11((char)((ushort)param_1 >> 8),in_stack_00000000);
+  cVar3 = func_0xa510();
+  if (cVar3 != '\0') {
+    FUN_df6a();
+    cVar3 = FUN_ded1();
+    if (cVar3 != '\0') {
+      while (puVar2 = puVar7, sVar5 = param_2 + -1, param_2 != 0) {
+        if (sVar5 == 0) {
+          bVar1 = IIC1C;
+          IIC1C = bVar1 | 8;
+        }
+        bVar1 = IIC1C;
+        IIC1C = bVar1 & 0xf7;
+        uVar4 = FUN_dfd2();
+        *puVar7 = uVar4;
+        cVar6 = cVar6 + '\x01';
+        if (cVar6 == '\0') {
+          cStack_1 = (char)((ushort)puVar7 >> 8);
+          puVar7 = (undefined1 *)CONCAT11(cStack_1 + '\x01',(char)puVar2);
+        }
+        DAT_012c = DAT_012c + '\x01';
+        param_2 = sVar5;
+        if (DAT_012c == '\0') {
+          DAT_012b = DAT_012b + '\x01';
+        }
+      }
+      FUN_df6a();
+      return 1;
+    }
+  }
+  return 0;
+}
+
+
+
+########## FUN_a631 @ a631 ##########
+
+void FUN_a631(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,2,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_a646 @ a646 ##########
+
+void FUN_a646(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,4,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_b596 @ b596 ##########
+
+void FUN_b596(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,5,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_b5ab @ b5ab ##########
+
+void FUN_b5ab(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,0x17,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_b5d5 @ b5d5 ##########
+
+void FUN_b5d5(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,1,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_b5ea @ b5ea ##########
+
+void FUN_b5ea(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  if ((char)((char)param_1 + '\x01') == '\0') {
+    param_1._0_1_ = param_1._0_1_ + '\x01';
+  }
+  FUN_a554(in_stack_00000000,0,4,param_1._0_1_,(char)param_1 + '\x01');
+  return;
+}
+
+
+
+########## FUN_b76f @ b76f ##########
+
+void FUN_b76f(undefined2 param_1,short param_2,undefined2 param_3)
+
+{
+  ushort uVar1;
+  undefined1 uVar2;
+  ushort uVar3;
+  undefined1 in_stack_00000000;
+  undefined1 uStack_f;
+  undefined2 local_e;
+  byte bStack_c;
+  short local_b;
+  undefined1 auStack_9 [8];
+  undefined1 uStack_1;
+  
+  uVar3 = CONCAT11((char)((ushort)param_1 >> 8),in_stack_00000000);
+  FUN_e088();
+  local_b = param_2;
+  for (; uVar1 = uVar3, uVar2 = (undefined1)((ushort)local_b >> 8), 8 < uVar3; uVar3 = uVar3 - 8) {
+    FUN_a554(auStack_9,0,8,uVar2,(char)local_b);
+    bStack_c = 0;
+    do {
+      local_e = param_3;
+      FUN_b802(&uStack_f);
+      FUN_e0cd();
+      bStack_c = bStack_c + 1;
+    } while (bStack_c < 8);
+    local_b = local_b + 8;
+  }
+  if (uVar3 != 0) {
+    uStack_1 = (undefined1)(uVar3 >> 8);
+    FUN_a554(auStack_9,uStack_1,(char)param_1,uVar2,(char)local_b);
+    uVar3 = uVar1;
+    for (bStack_c = 0; bStack_c < uVar3; bStack_c = bStack_c + 1) {
+      local_e = param_3;
+      FUN_b802(&uStack_f);
+      FUN_e0cd();
+    }
+  }
+  return;
+}
+
+
+
+########## FUN_b5c0 @ b5c0 ##########
+
+void FUN_b5c0(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,0x19,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_a61c @ a61c ##########
+
+void FUN_a61c(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_a554(in_stack_00000000,0,1,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_bb8e @ bb8e ##########
+
+void FUN_bb8e(void)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_bca8();
+  FUN_a554(in_stack_00000000,0,5,0x3a,0x9d);
+  return;
+}
+
+
+
+########## FUN_bbe8 @ bbe8 ##########
+
+void FUN_bbe8(undefined2 param_1)
+
+{
+  undefined1 in_stack_00000000;
+  
+  FUN_bca8();
+  FUN_a554(in_stack_00000000,0,0x10,(char)((ushort)param_1 >> 8),(char)param_1);
+  return;
+}
+
+
+
+########## FUN_dd9c @ dd9c ##########
+
+/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */
+
+void FUN_dd9c(void)
+
+{
+  if (_DAT_06ea == 0) {
+    if (_DAT_06ec != 0) {
+      FUN_a554(_DAT_069b,DAT_06ec,DAT_06ed);
+      FUN_de08();
+      FUN_de12(DAT_06ed);
+      DAT_0142 = 0;
+      _DAT_06ec = 0;
+      _DAT_06ea = 0;
+    }
+  }
+  else {
+    FUN_a554(0,0x11);
+    _DAT_06ef = _DAT_06ef + 0x11;
+    FUN_de08();
+    FUN_de12();
+    if (DAT_06eb == '\0') {
+      _DAT_06ea = (ushort)(byte)(DAT_06ea - 1) << 8;
+    }
+    _DAT_06ea = CONCAT11(DAT_06ea,DAT_06eb + -1);
+    if ((_DAT_06ea == 0) && (_DAT_06ec == 0)) {
+      DAT_0142 = 0;
+      return;
+    }
+  }
+  return;
+}
+
+
+
+########## FUN_ded1 @ ded1 ##########
+
+/* WARNING: Instruction at (RAM,0xdf3e) overlaps instruction at (RAM,0xdf3d)
+    */
+/* WARNING: Possible PIC construction at 0xdf3e: Changing call to branch */
+/* WARNING: Possible PIC construction at 0xdf1c: Changing call to branch */
+
+undefined1 FUN_ded1(undefined1 param_1)
+
+{
+  char extraout_A;
+  char cVar1;
+  char extraout_A_00;
+  char extraout_A_01;
+  undefined1 uVar2;
+  short sVar3;
+  undefined1 *puVar4;
+  byte bVar5;
+  byte bVar6;
+  undefined1 uStack_b;
+  undefined2 uStack_a;
+  undefined1 local_4 [4];
+  
+  bVar5 = IIC1C;
+  IIC1C = bVar5 | 0x10;
+  bVar5 = IIC1C;
+  IIC1C = bVar5 & 0xdf;
+  bVar5 = 2;
+  uStack_a = (undefined *)0xdedf;
+  FUN_912a(0,local_4);
+  uStack_a = (undefined *)0xdee5;
+  sVar3 = FUN_9d8e(local_4);
+  bVar6 = PTAD;
+  bVar5 = bVar5 & 0xfe;
+  if ((bVar6 & 1) == 0) {
+                    /* WARNING: Subroutine does not return */
+    uStack_a = &UNK_deee;
+    FUN_9e26(extraout_A - *(char *)(sVar3 + -0x5004));
+  }
+  cVar1 = extraout_A;
+  puVar4 = (undefined1 *)((short)&uStack_a + 1);
+  if ((DAT_00ad & 8) != 0) {
+    while( true ) {
+      if ((bVar5 >> 1 & 1) == 0) {
+        return 0;
+      }
+      SRS = cVar1;
+      bVar5 = (cVar1 == '\0') << 1;
+      bVar6 = IIC1S;
+      if ((bVar6 & 0x20) == 0) break;
+      uStack_a = (undefined *)0xdef2;
+      cVar1 = func_0xdf59();
+    }
+    bVar5 = IIC1S;
+    IIC1S = bVar5 | 0x10;
+    bVar5 = IIC1C;
+    IIC1C = bVar5 | 0x10;
+    bVar5 = IIC1C;
+    IIC1C = bVar5 | 0x20;
+    IIC1D = param_1;
+    bVar6 = 2;
+    uStack_a = (undefined *)0xdf0b;
+    FUN_912a(0,local_4);
+    uStack_a = (undefined *)0xdf11;
+    sVar3 = FUN_9d8e(local_4);
+    bVar5 = PTAD;
+    if ((bVar5 & 1) == 0) {
+                    /* WARNING: Subroutine does not return */
+      uStack_a = &UNK_df1a;
+      FUN_9e26(extraout_A_00 - *(char *)(sVar3 + -0x5004));
+    }
+    puVar4 = (undefined1 *)((short)&uStack_a + 1);
+    if ((DAT_00ad & 8) != 0) {
+      if ((bVar6 >> 1 & 1) == 0) {
+        return 0;
+      }
+      SRS = extraout_A_00;
+      bVar5 = IIC1S;
+      if ((bVar5 & 0x80) == 0) {
+        bVar6 = 2;
+        uStack_a = (undefined *)0xdf2d;
+        FUN_912a(0,local_4);
+        uStack_a = (undefined *)0xdf33;
+        sVar3 = FUN_9d8e(local_4);
+        bVar5 = PTAD;
+        if ((bVar5 & 1) == 0) {
+                    /* WARNING: Subroutine does not return */
+          uStack_a = &UNK_df3c;
+          FUN_9e26(extraout_A_01 - *(char *)(sVar3 + -0x5004));
+        }
+        puVar4 = (undefined1 *)((short)&uStack_a + 1);
+        if ((DAT_00ad & 8) != 0) {
+          if ((bVar6 >> 1 & 1) == 0) {
+            return 0;
+          }
+          SRS = extraout_A_01;
+          bVar5 = IIC1S;
+          if ((bVar5 & 0x80) != 0) {
+            bVar5 = IIC1S;
+            if (((bVar5 & 0x10) == 0) && (bVar5 = IIC1S, (bVar5 & 1) == 0)) {
+              return 1;
+            }
+            uStack_a = (undefined *)0xdf55;
+            FUN_df6a();
+            return 0;
+          }
+          uStack_a = (undefined *)0xdf40;
+          puVar4 = &uStack_b;
+        }
+      }
+      else {
+        uStack_a = (undefined *)0xdf1e;
+        puVar4 = &uStack_b;
+      }
+    }
+  }
+  *puVar4 = (char)*(undefined2 *)(puVar4 + 5);
+  puVar4[-1] = (char)((ushort)*(undefined2 *)(puVar4 + 5) >> 8);
+  puVar4[-2] = (char)*(undefined2 *)(puVar4 + 3);
+  puVar4[-3] = (char)((ushort)*(undefined2 *)(puVar4 + 3) >> 8);
+  *(undefined2 *)(puVar4 + -5) = 0xdf66;
+  uVar2 = FUN_e03a();
+  return uVar2;
+}
+
+
+
+########## FUN_a4f0 @ a4f0 ##########
+
+/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */
+
+undefined1 FUN_a4f0(void)
+
+{
+  char cVar1;
+  undefined1 uVar2;
+  
+  cVar1 = FUN_ded1();
+  uVar2 = 0;
+  if (cVar1 != '\0') {
+    FUN_df6a();
+    cVar1 = func_0xa510(0);
+    if (cVar1 == '\0') {
+      return 0;
+    }
+    FUN_df6a();
+    _DAT_012b = 0;
+    uVar2 = 1;
+  }
+  return uVar2;
+}
+
+
+
+########## FUN_dfd2 @ dfd2 ##########
+
+/* WARNING: Instruction at (RAM,0xe014) overlaps instruction at (RAM,0xe013)
+    */
+/* WARNING: Possible PIC construction at 0xe014: Changing call to branch */
+/* WARNING: Possible PIC construction at 0xdff2: Changing call to branch */
+
+undefined1 FUN_dfd2(void)
+
+{
+  byte bVar1;
+  char extraout_A;
+  char extraout_A_00;
+  undefined1 uVar2;
+  short sVar3;
+  undefined1 *puVar4;
+  byte bVar5;
+  undefined1 uStack_b;
+  undefined2 uStack_a;
+  undefined1 local_4 [4];
+  
+  bVar1 = IIC1C;
+  IIC1C = bVar1 & 0xef;
+  uVar2 = IIC1D;
+  bVar5 = 2;
+  uStack_a = (undefined *)0xdfe1;
+  FUN_912a(0,local_4);
+  uStack_a = (undefined *)0xdfe7;
+  sVar3 = FUN_9d8e(local_4);
+  puVar4 = (undefined1 *)((short)&uStack_a + 1);
+  bVar1 = PTAD;
+  if ((bVar1 & 1) == 0) {
+                    /* WARNING: Subroutine does not return */
+    uStack_a = &UNK_dff0;
+    FUN_9e26(extraout_A - *(char *)(sVar3 + -0x5004));
+  }
+  if ((DAT_00ad & 8) != 0) {
+    if ((bVar5 >> 1 & 1) == 0) {
+      return 0xff;
+    }
+    SRS = extraout_A;
+    bVar1 = IIC1S;
+    if ((bVar1 & 0x80) == 0) {
+      bVar5 = 2;
+      uStack_a = (undefined *)0xe003;
+      FUN_912a(0,local_4);
+      uStack_a = (undefined *)0xe009;
+      sVar3 = FUN_9d8e(local_4);
+      puVar4 = (undefined1 *)((short)&uStack_a + 1);
+      bVar1 = PTAD;
+      if ((bVar1 & 1) == 0) {
+                    /* WARNING: Subroutine does not return */
+        uStack_a = &UNK_e012;
+        FUN_9e26(extraout_A_00 - *(char *)(sVar3 + -0x5004));
+      }
+      if ((DAT_00ad & 0x20) != 0) {
+        if ((bVar5 >> 1 & 1) != 1) {
+          return 0xff;
+        }
+        SRS = extraout_A_00;
+        bVar1 = IIC1S;
+        if ((bVar1 & 0x80) != 0) {
+          bVar1 = IIC1C;
+          IIC1C = bVar1 | 0x10;
+          uVar2 = IIC1D;
+          return uVar2;
+        }
+        uStack_a = (undefined *)0xe016;
+        puVar4 = &uStack_b;
+      }
+    }
+    else {
+      uStack_a = (undefined *)0xdff4;
+      puVar4 = &uStack_b;
+    }
+  }
+  *puVar4 = (char)*(undefined2 *)(puVar4 + 5);
+  puVar4[-1] = (char)((ushort)*(undefined2 *)(puVar4 + 5) >> 8);
+  puVar4[-2] = (char)*(undefined2 *)(puVar4 + 3);
+  puVar4[-3] = (char)((ushort)*(undefined2 *)(puVar4 + 3) >> 8);
+  *(undefined2 *)(puVar4 + -5) = 0xe036;
+  uVar2 = FUN_e03a();
+  return uVar2;
+}
+
+
+
+########## FUN_df6a @ df6a ##########
+
+void FUN_df6a(void)
+
+{
+  byte bVar1;
+  
+  bVar1 = IIC1C;
+  IIC1C = bVar1 | 0x10;
+  bVar1 = IIC1C;
+  IIC1C = bVar1 & 0xdf;
+  return;
+}
+
+
+
+########## FUN_a5c9 @ a5c9 ##########
+
+undefined1 FUN_a5c9(short param_1,byte param_2)
+
+{
+  char cVar1;
+  short sVar2;
+  
+  while (cVar1 = func_0xa510(), cVar1 != '\0') {
+    do {
+      sVar2 = param_1 + -1;
+      if (param_1 == 0) {
+        FUN_df6a();
+        return 1;
+      }
+      cVar1 = FUN_df6f();
+      if (cVar1 == '\0') goto LAB_a5d4;
+      DAT_012c = DAT_012c + '\x01';
+      if (DAT_012c == '\0') {
+        DAT_012b = DAT_012b + '\x01';
+      }
+      param_2 = param_2 + 1;
+      param_1 = sVar2;
+    } while ((param_2 & 0x3f) != 0);
+    FUN_df6a();
+  }
+LAB_a5d4:
+  FUN_df6a();
+  return 0;
+}
+
+
+
+########## FUN_a5a5 @ a5a5 ##########
+
+undefined1 FUN_a5a5(void)
+
+{
+  char cVar1;
+  
+  cVar1 = func_0xa510();
+  if (cVar1 != '\0') {
+    cVar1 = FUN_df6f();
+    if (cVar1 != '\0') {
+      DAT_012c = DAT_012c + '\x01';
+      if (DAT_012c == '\0') {
+        DAT_012b = DAT_012b + '\x01';
+      }
+      FUN_df6a();
+      return 1;
+    }
+  }
+  FUN_df6a();
+  return 0;
+}
+
+
+

--- a/docs/ghidra/periph_init.c
+++ b/docs/ghidra/periph_init.c
@@ -1,0 +1,202 @@
+/*
+ * Ghidra decompiler output — peripheral init (runs from reset).
+ *
+ * Auto-generated, NOT hand-written or compilable. Reproduce with:
+ *   tools/analyze.sh DecompileCallers.java periph_init.c fe80
+ *
+ * Key line for the radio question: `SPI1C1 = 0xcc;` sets MSTR=0, so the
+ * MC9S08 is the SPI *slave* — it does not drive the nRF905 config. Also sets
+ * the I2C registers (IIC1A/IIC1F/IIC1C) and SCI/clock/port directions.
+ */
+
+########## FUN_fe80 @ fe80 ##########
+
+undefined2 FUN_fe80(void)
+
+{
+  byte bVar1;
+  undefined1 uVar2;
+  
+  SOPT = 0xd1;
+  SPMSC1 = 0x1c;
+  SPMSC2 = 0;
+  ICGC1 = 0x3c;
+  ICGC2 = 0x70;
+  while (bVar1 = ICGS1, (bVar1 & 8) == 0) {
+    SRS = 0;
+  }
+  PTASE = 0;
+  PTBSE = 0;
+  PTCSE = 0;
+  bVar1 = PTDSE;
+  PTDSE = bVar1 & 0xe0;
+  bVar1 = PTESE;
+  PTESE = bVar1 & 0xc0;
+  bVar1 = PTGSE;
+  PTGSE = bVar1 & 0xf0;
+  TPM1SC = 0;
+  RAM0033 = 0x10;
+  uVar2 = TPM1SC;
+  TPM1SC = 0x50;
+  bVar1 = PTDD;
+  PTDD = bVar1 & 0xe4;
+  bVar1 = PTDPE;
+  PTDPE = bVar1 & 0xfe;
+  bVar1 = PTDDD;
+  PTDDD = bVar1 | 0x1b;
+  IIC1A = 6;
+  IIC1F = 0x2f;
+  IIC1S = 0x12;
+  bVar1 = IIC1C;
+  IIC1C = bVar1 | 0x80;
+  PTAD = 0;
+  PTAPE = 0;
+  PTADD = 0xff;
+  SCI1C2 = 0;
+  uVar2 = SCI1S1;
+  uVar2 = SCI1D;
+  SCI1BDH = 0;
+  SCI1BDL = 0x7b;
+  SCI1C1 = 0;
+  SCI1C3 = 0;
+  SCI1C2 = 0x2c;
+  SPI1C1 = 0;
+  SPI1C2 = 0;
+  SPI1BR = 0x23;
+  uVar2 = SPI1S;
+  SPI1C1 = 0xcc;
+  bVar1 = PTBPE;
+  PTBPE = bVar1 | 1;
+  bVar1 = PTBDD;
+  PTBDD = bVar1 & 0xfe | 0xde;
+  bVar1 = PTCD;
+  PTCD = bVar1 | 0x50;
+  bVar1 = PTCPE;
+  PTCPE = bVar1 & 0x8f;
+  bVar1 = PTCDD;
+  PTCDD = bVar1 & 0xdf | 0x50;
+  SCI2C2 = 0;
+  uVar2 = SCI2S1;
+  uVar2 = SCI2D;
+  SCI2BDH = 0;
+  SCI2BDL = 0x7b;
+  SCI2C1 = 0;
+  SCI2C3 = 0x20;
+  SCI2C2 = 0x2c;
+  bVar1 = IRQSC;
+  IRQSC = bVar1 & 0xfd;
+  bVar1 = IRQSC;
+  IRQSC = bVar1 | 0x10;
+  bVar1 = IRQSC;
+  IRQSC = bVar1 | 4;
+  SRS = 0xff;
+  FSTAT = 0x30;
+  FCDIV = 0x4d;
+  return 0x10;
+}
+
+
+
+########## FUN_92fb @ 92fb ##########
+
+/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */
+
+void FUN_92fb(void)
+
+{
+  byte bVar1;
+  undefined1 uVar2;
+  char cVar3;
+  
+  FUN_fe80();
+  FUN_92e8();
+  FUN_bdd8();
+  FUN_8fc4(0,0xff,0xff);
+  uVar2 = FUN_a728();
+  SRS = uVar2;
+  FUN_bccc();
+  if (DAT_0606 == '\0') {
+    DAT_05ec = DAT_0606;
+    FUN_a460();
+  }
+  else {
+    if (DAT_06e9 == '\x01') {
+      DAT_05ec = DAT_06e9;
+      DAT_0111 = 1;
+    }
+    bVar1 = SCI1C2;
+    SCI1C2 = bVar1 | 8;
+    bVar1 = SCI1C2;
+    SCI1C2 = bVar1 | 4;
+  }
+  FUN_d017();
+  FUN_d007();
+  FUN_caca();
+  cVar3 = FUN_a489();
+  if (cVar3 != '\0') {
+    FUN_de96();
+    DAT_05ec = '\x01';
+    DAT_0111 = 1;
+    goto LAB_9382;
+  }
+  if (DAT_06e9 == '\0') {
+LAB_9378:
+    if (DAT_06e9 != '\0') goto LAB_9382;
+  }
+  else {
+    cVar3 = FUN_de1b((char)((ushort)_DAT_013e >> 8),(char)_DAT_013e);
+    if (cVar3 == '\0') goto LAB_9378;
+  }
+  FUN_a460();
+LAB_9382:
+  do {
+    if (DAT_0150 == '\0') {
+      if (DAT_014b == '\0') {
+        SRS = 0;
+        uVar2 = FUN_c03c();
+        SRS = uVar2;
+        uVar2 = FUN_97cd();
+        SRS = uVar2;
+        uVar2 = FUN_a339();
+        SRS = uVar2;
+        uVar2 = FUN_d02f();
+        SRS = uVar2;
+        uVar2 = 0;
+        if (DAT_014a != '\0') {
+          uVar2 = FUN_93f8();
+        }
+        SRS = uVar2;
+        cVar3 = DAT_0139;
+        if (DAT_0139 == '\0') {
+          FUN_e0e5();
+          cVar3 = FUN_e32c();
+        }
+        SRS = cVar3;
+        uVar2 = FUN_dbb3();
+        SRS = uVar2;
+        FUN_fc7c();
+      }
+      else {
+        SRS = DAT_014b;
+        FUN_e4d0();
+        FUN_e525();
+        FUN_d02f();
+        if (DAT_014a != '\0') {
+          FUN_93f8();
+        }
+      }
+    }
+    else {
+      SRS = DAT_0150;
+      FUN_e541();
+      FUN_e5eb();
+    }
+  } while (_DAT_075f == -0x55ab);
+  FUN_94e9(0x29a);
+  do {
+                    /* WARNING: Do nothing block with infinite loop */
+  } while( true );
+}
+
+
+


### PR DESCRIPTION
## Summary
- Move the **Path B firmware analysis** out of `README.md` into a dedicated **`docs/ghidra-firmware-analysis.md`**.
- Document **exactly how the headless Ghidra analysis was run**: the `MotorolaHexLoader` class-name loader + `HCS08:BE:16:MC9S08GB60` processor, the exact `analyzeHeadless` command, the commands used, and the gotchas (scripts must be Java not Python; write decompiler C to a file to avoid log-prefix mangling; `0xBD56` won't decompile because it's in a code gap).
- Add the **generated decompiler C** under `docs/ghidra/`:
  - `eeprom_i2c.c` — the M24128/U3 I2C access layer (`FUN_a554` sequential read + the length-typed wrappers + `FUN_ded1`/`FUN_dfd2`/`FUN_df6a`).
  - `periph_init.c` — reset-time init; the `SPI1C1 = 0xcc;` line is the primary evidence that the MC9S08 is the SPI **slave** (so the nRF905 config is not in this dump).
- `README.md` firmware section is now a short pointer to the new page.

## Notes
- The C files are auto-generated decompiler output (not compilable); each carries a header with the exact reproduce command.
- The tooling those commands reference (`tools/analyze.sh`, `tools/ghidra/*.java`) ships in #50; merging that puts it on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)