### PR TITLE
Add rtl_433 decoder (100 kbps Manchester) and firmware field analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Raw RTL-SDR IQ captures - large binaries, kept locally only.
+*.cu8

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -187,7 +187,8 @@ and TX_ADDRESS holds the address bytes.
 Before integrating C, sanity-check demodulation with rtl_433's built-in flex
 decoder (`-X`). At the measured 100 kbps (10 us/bit):
 
-    rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
+    rtl_433 -f 868.20M -Y minmax \
+      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
 
 - `m=FSK_PCM`  FSK with NRZ/PCM coding. This prints the **raw on-air bits**,
   i.e. the Manchester-*encoded* stream - decode it by eye (raw `01`->1, `10`->0)
@@ -202,11 +203,17 @@ decoder (`-X`). At the measured 100 kbps (10 us/bit):
   (4 events x near+far), which is what you want.
 - `bits>=400`  drops the noise rows. Real packets are ~635-654 raw bits; stray
   detections are <100, so this filter removes them without touching real frames.
+- `preamble={32}55599566`  the **same `fd 7a` sync the C decoder anchors on**, but
+  expressed in the raw (Manchester-*encoded*) domain so it can match the on-air
+  bits. Decoded `fd 7a` = `11111101 01111010`; encode each bit (`1`->`01`,
+  `0`->`10`) and you get raw `0x5559 0x9566`. This strips the leading `0xBA`
+  preamble run and aligns every packet to the same start - in the replay above all
+  8 packets then begin right at the header, so the rows line up byte-for-byte.
 
 You can replay a saved capture instead of live SDR (match the capture rate):
 
     rtl_433 -r uclean_offset.cu8 -s 1024k -Y minmax \
-      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
+      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
 
 Note: the flex `decode_mc` (native Manchester) option does **not** work here - it
 aborts at the first Manchester violation and only tries phase 0, so these

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -129,6 +129,57 @@ setpoint tables above), not their positions.
 
 ---
 
+## 0c. Decoded reference frames (baseline)
+
+These are the two frames actually recovered on-air, to serve as a **fixed diff
+target** for future display-correlated captures. Obtained with the flex decoder
+(demodulator-level Manchester, see section 2):
+
+    rtl_433 -f 868.20M -Y minmax \
+      -X 'n=uclean1,m=FSK_MC_ZEROBIT,s=10,r=100,bits>=200,invert'
+
+Every ~62 s exchange is one **poll** + one **response**. Across ~35 min of
+capture (two sessions, ~30 exchanges) both frames were **byte-identical** — the
+only differences were isolated single-bit demod errors in individual noisy
+packets (e.g. one poll read `…49 2e 61 b1 ef…` instead of `…49 2e 71 b0 2f…`).
+Align each row on the `fd 7a` header first (the frame starts a few bits into a
+byte, so byte 0 of the row is meaningless — see section 2).
+
+Header (constant on every frame): `fd 7a ba ba ba 83`
+
+| frame    | payload bytes (after the 6-byte header) |
+| ---      | --- |
+| poll     | `73 1b 93 e0 03 5b b0 08 d2 c0 49 2e 71 b0 2f 4f fc bd 2e 2a` … |
+| response | `33 1b a3 f0 08 d2 e0 03 5b 80 1c 11 71 f5 1d 2c ff ef 7f 3b` … |
+
+(The frames continue for ~13 more stable bytes into a low-SNR tail; the exact
+end-of-payload / CRC boundary is still `[U5]`/`[U4]`, so only the confident head
+is tabulated.)
+
+### What the structure tells us (no display correlation yet)
+
+- **No counter, nonce, or rolling code.** Nothing increments between exchanges;
+  this is pure repeated telemetry. (Good for Home Assistant — no replay/rolling
+  handling — but it means fields can only be found by *changing* the unit.)
+- **Byte 1 = `0x1b`** in both frames — a constant, likely a protocol/type byte.
+- **A pair of 3-byte fields is swapped between poll and response** — the classic
+  source/destination signature, i.e. the two units' **node IDs**:
+  - poll carries `(03 5b b0)(08 d2 c0)`, response carries `(08 d2 e0)(03 5b 80)`.
+  - So `03 5b _` = one unit, `08 d2 _` = the other; the request/reply swaps them.
+- Bytes 0/2/3 differ between the two (`73 93 e0` vs `33 a3 f0`) — a
+  direction/type/flags region.
+- Everything from byte ~10 onward is the telemetry payload proper, still static
+  and therefore still unmapped (`[U6]`).
+
+### How to use this baseline
+
+Run a **display-correlated capture** (section 1), then diff the recovered frame
+against the row above. Any byte that moves is that field; the firmware tables in
+0b then say what it means (alarm byte → alarm table; a setpoint edit should shift
+by the known step). Change **one** thing at a time.
+
+---
+
 ## 1. Capture raw IQ for analysis
 
 You need real captures before the decoder can be validated. Based on section 0,

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -187,8 +187,7 @@ and TX_ADDRESS holds the address bytes.
 Before integrating C, sanity-check demodulation with rtl_433's built-in flex
 decoder (`-X`). At the measured 100 kbps (10 us/bit):
 
-    rtl_433 -f 868.20M -Y minmax \
-      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
+    rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
 
 - `m=FSK_PCM`  FSK with NRZ/PCM coding. This prints the **raw on-air bits**,
   i.e. the Manchester-*encoded* stream - decode it by eye (raw `01`->1, `10`->0)
@@ -203,17 +202,31 @@ decoder (`-X`). At the measured 100 kbps (10 us/bit):
   (4 events x near+far), which is what you want.
 - `bits>=400`  drops the noise rows. Real packets are ~635-654 raw bits; stray
   detections are <100, so this filter removes them without touching real frames.
-- `preamble={32}55599566`  the **same `fd 7a` sync the C decoder anchors on**, but
-  expressed in the raw (Manchester-*encoded*) domain so it can match the on-air
-  bits. Decoded `fd 7a` = `11111101 01111010`; encode each bit (`1`->`01`,
-  `0`->`10`) and you get raw `0x5559 0x9566`. This strips the leading `0xBA`
-  preamble run and aligns every packet to the same start - in the replay above all
-  8 packets then begin right at the header, so the rows line up byte-for-byte.
+
+Optional - align rows to the header with a preamble anchor:
+
+    rtl_433 -f 868.20M -Y minmax \
+      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
+
+`preamble={32}55599566` is the **same `fd 7a` sync the C decoder anchors on**, but
+expressed in the raw (Manchester-*encoded*) domain so it can match the on-air
+bits. Decoded `fd 7a` = `11111101 01111010`; encode each bit (`1`->`01`, `0`->`10`)
+and you get raw `0x5559 0x9566`. It strips the leading `0xBA` run so every row
+begins right at the header.
+
+**But keep the preamble optional.** The flex `preamble` is an *exact* match over
+all 32 raw bits, in the noisier raw domain (each decoded bit is two raw bits), so a
+single noise-flipped bit in the sync drops the **whole** packet. On a live capture
+that intermittently loses the weaker (far-unit) packet of an exchange - you get one
+message instead of two. The C decoder avoids this by Manchester-decoding with
+tolerance *first* and only then bit-searching for `fd 7a`, so a stray bit costs
+alignment, not the frame. Use `bits>=400` alone when you want to catch **every**
+message; add `preamble` only when you want tidy aligned rows from a clean signal.
 
 You can replay a saved capture instead of live SDR (match the capture rate):
 
     rtl_433 -r uclean_offset.cu8 -s 1024k -Y minmax \
-      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
+      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
 
 Note: the flex `decode_mc` (native Manchester) option does **not** work here - it
 aborts at the first Manchester violation and only tries phase 0, so these

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -185,21 +185,35 @@ and TX_ADDRESS holds the address bytes.
 ## 2. Quick first pass with the flex decoder
 
 Before integrating C, sanity-check demodulation with rtl_433's built-in flex
-decoder (`-X`). Assuming 50 kbps (20 us/bit):
+decoder (`-X`). At the measured 100 kbps (10 us/bit):
 
-    rtl_433 -f 868.35M -X 'n=uclean1,m=FSK_PCM,s=20,l=20,r=200'
+    rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
 
-- `m=FSK_PCM`  FSK with NRZ/PCM coding (matches nRF905).
-- `s=20 l=20`  short = long = 20 us/bit (50 kbps). Use `s=10 l=10` for 100 kbps.
-- `r=200`      reset limit ~10 bit periods; ends the short ShockBurst frame.
+- `m=FSK_PCM`  FSK with NRZ/PCM coding. This prints the **raw on-air bits**,
+  i.e. the Manchester-*encoded* stream - decode it by eye (raw `01`->1, `10`->0)
+  or use the C decoder for the real payload.
+- `s=10 l=10`  short = long = 10 us/bit (100 kbps).
+- `r=100`      reset limit; ends a packet after ~10 bit periods with no
+  transition. Manchester guarantees a transition every <=2 bits, so this keeps a
+  packet whole yet still splits the two packets of an exchange (~19 ms apart).
+- `-Y minmax`  **selects the FSK peak detector.** Without it the default detector
+  fragments the weaker (far-unit) packet into several short rows. With it, a
+  4-event replay of `uclean_offset.cu8` yields 8 clean ~650-bit packets
+  (4 events x near+far), which is what you want.
+- `bits>=400`  drops the noise rows. Real packets are ~635-654 raw bits; stray
+  detections are <100, so this filter removes them without touching real frames.
 
-You can also replay a saved capture instead of live SDR:
+You can replay a saved capture instead of live SDR (match the capture rate):
 
-    rtl_433 -r g001_868.35M_1024k.cu8 -X 'n=uclean1,m=FSK_PCM,s=20,l=20,r=200'
+    rtl_433 -r uclean_offset.cu8 -s 1024k -Y minmax \
+      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
 
-The flex output prints the raw bitrows. Confirm the preamble/address/payload/CRC
-layout matches the nRF905 frame, then fold the confirmed values into
-`tools/rtl433/uponor_clean1.c`.
+Note: the flex `decode_mc` (native Manchester) option does **not** work here - it
+aborts at the first Manchester violation and only tries phase 0, so these
+phase-offset, slightly-noisy packets collapse to empty rows. That is exactly why
+`tools/rtl433/uponor_clean1.c` does its own violation-tolerant, two-phase
+Manchester pass. Use the C decoder (`-R <num>`) for the actual decoded payload;
+use this flex command only to confirm clean bit recovery.
 
 ---
 

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -1,0 +1,263 @@
+# rtl_433 decoder for the Uponor Clean 1 (868.35 MHz)
+
+Goal: capture the 868.35 MHz link between the Clean 1 inner and outer units with
+an RTL-SDR, decode it to JSON with [rtl_433](https://github.com/merbanan/rtl_433/),
+and forward to Home Assistant over MQTT.
+
+The transmitter is a Nordic **nRF9E5** (= nRF905 transceiver + 8051 MCU), so the
+air protocol is nRF905 "ShockBurst": **GFSK**, NRZ line coding (NOT OOK, NOT
+Manchester), default **50 kbps**, carrier **868.35 MHz**.
+
+nRF905 ShockBurst frame:
+
+    PREAMBLE(10 bits) | ADDRESS(1-4 B, default 4) | PAYLOAD(1-32 B) | CRC(0/8/16, default 16)
+
+CRC-16: poly `0x1021` (x^16+x^12+x^5+1), init `0xFFFF`, MSB-first, over
+ADDRESS+PAYLOAD.
+
+The decoder skeleton lives at `tools/rtl433/uponor_clean1.c`.
+
+---
+
+## 0. Empirical results from the first real capture
+
+A 21.6-minute continuous capture at 250 kS/s (`-f 868.35M`) was analysed offline
+(FM discriminator + power-envelope scan in numpy, cross-checked with `rtl_433
+-A`). Confirmed:
+
+- **Cadence:** one radio event every **~62 s** (not the ~10 min that was
+  assumed). ~20 events in the capture, very regular.
+- **Each event is a two-packet exchange**, not a single frame:
+  a **~6.2 ms** packet, a **~19 ms** gap, then a **~6.6 ms** packet. The two
+  packets have very different RSSI (one much stronger) -> the near/far units
+  (mainboard <-> tank sensor) answering each other. This matches an nRF905
+  bidirectional ShockBurst link.
+- **Modulation:** FSK, deviation **~+-38 kHz**. Per-packet length ~6.3 ms =>
+  ~300 bits => **~35-40 bytes** at 50 kbps - consistent with the nRF905 default
+  50 kbps and a ~32-byte payload + address + CRC.
+
+Two gotchas this capture hit - **fix them on the next capture (section 1):**
+
+1. **Carrier was ~76 kHz *below* the tune center**, landing right on the
+   RTL-SDR's DC self-mixing spike. rtl_433's detector locked onto DC and saw
+   nothing.
+2. **Signal amplitude was low** (~11 counts above the 127.5 mid) - the RX gain
+   was too conservative, so the burst sat near rtl_433's detection floor.
+
+After frequency-shifting the signal off DC and lowering the thresholds, rtl_433
+does detect and FSK-demodulate it:
+
+    rtl_433 -r shifted.cu8 -s 250k -R 0 \
+      -X 'n=uclean1,m=FSK_PCM,s=20,l=20,r=400' \
+      -Y minmax -Y minlevel=-40 -Y minsnr=3 -M level
+
+### Decoded from the second (off-center, high-gain) capture
+
+A 5-minute capture at `-f 868.20M -s 1024k -g 49` (signal at +128 kHz, peak/noise
+371x) demodulated cleanly. Per-packet analysis (FM discriminator + phase-searched
+resample in numpy):
+
+- **Line rate is 100 kbps, NOT 50 kbps.** Transition-spacing histogram clusters
+  hard at 10 samples (@1.024 MS/s = 10.24 samp/bit = 100 kbps).
+- **The payload is Manchester-encoded.** Every demodulated byte decomposes into
+  `01`/`10` pairs; a Manchester decode gives only **~3–4 % illegal pairs**
+  (random NRZ would be ~50 %). So the raw 100 kbps line carries **~50 kbps of
+  Manchester data**, ~40 bytes/packet — which fits the nRF905 frame. The nRF9E5's
+  8051 is doing the Manchester coding in software; the radio itself is NRZ.
+- **Constant header/address:** after a `ababab` sync run every packet carries a
+  constant `fd 7a … 83` region.
+- **Payloads are near-static:** 3 of 4 consecutive events (~62 s apart) were
+  **byte-identical** for ~38 bytes; only occasionally does the tail change. Makes
+  sense — the tank state changes slowly. The varying tail bytes are the real
+  telemetry.
+
+**Impact on the decoder:** `tools/rtl433/uponor_clean1.c` assumes plain NRZ at
+50 kbps. It must instead demod at **100 kbps** and **Manchester-decode** before
+the address/CRC logic (rtl_433 flex `m=FSK_MC_ZEROBIT` / `DMC`, or a manual
+Manchester pass in the C decoder). `[U1]` is resolved; `[U2]/[U3]` (address) ≈ the
+constant `fd7a…83` bytes; `[U5]` payload ≈ ~30 bytes; `[U6]` field semantics still
+need correlation against the unit's display.
+
+Clean per-packet bit recovery is working; remaining work is exact byte alignment,
+CRC location, and mapping the varying tail bytes to physical quantities.
+
+---
+
+## 0b. What the MC9S08 firmware says about the fields
+
+The CPU flash (`dumps/u2-mc9s08gt-flash.s19`) was analysed headless in Ghidra
+(`tools/ghidra/*.java`, run via `tools/analyze.sh`; see also
+[docs/ghidra-firmware-analysis.md](ghidra-firmware-analysis.md)) to see whether the decoded
+radio payload's byte layout could be recovered from the receiver side. The
+short answer: **the on-air byte semantics are not in this flash** — but the
+analysis is still useful because it pins down the architecture and gives the
+decode *targets*.
+
+Findings:
+
+- **The SPI link is a custom MC9S08↔8051 message bus, not nRF905 register
+  access.** SPI1C1 = 0xCC (MSTR=0) — the MC9S08 is the SPI *slave*; the nRF9E5's
+  8051 is the master and owns the nRF905. So the MC9S08 never sees nRF905
+  CONFIG/addresses, and the on-air framing we measured (`fd7a`, `bababa` sync,
+  the `83` tag, and the software Manchester coding) is entirely the **8051's**
+  doing and is **invisible in this dump**. This confirms the radio PHY has to be
+  reverse-engineered from captures, not from the CPU flash.
+- **SPI receive engine** (ISR at vector `0xFFE0` → `0xbd56`, armed by
+  `FUN_bcdb`): buffer pointer at RAM `0x0600/0x0601`, byte counter `0x0602`, TX
+  length `0x0603`, transfer-complete flag `0x0606`; a 16-bit running counter at
+  `0x012e` tears the transfer down (disables SPI, `SPI1C1 &= 0x7f`) when it
+  reaches `0x67a`. The ISR decompiles poorly (overlapping instructions) so
+  byte-level tracing from it is unreliable.
+- **Inter-MCU message format** (`FUN_db22`, message types `0x20 0x21 0x22 0x23
+  0x26`; a 7-byte init message `02 00 2b 32 ff ff ff` at flash `0x80bb`): each
+  message carries **four live 16-bit variables** from RAM `0x013e 0x0140 0x0109
+  0x010b` plus a 2-byte header at `0x06be/0x06bf`. These are the CPU-side state
+  words, i.e. what the CPU reports up to the 8051 — a strong hint at how many
+  telemetry quantities exist, but not their on-air byte offsets.
+- **Decode targets, initialised by `FUN_bdd8`:** a 12-entry × 8-byte alarm table
+  at RAM `0x06f7` whose codes match the EEPROM alarm table exactly (`0x28`
+  compressor, `0x29`–`0x2d` MV1–5, `0x2f` EEPROM error, `0x33`, …), plus a large
+  setpoint/timer block at `0x055c`–`0x05ea` (durations such as 600, 900, 3000,
+  6000, `0x1518`=5400). The decoded payload codes should index into this alarm
+  table and the phase names.
+
+**Conclusion for [U6]:** the payload→field binding lives on the 8051, not here,
+so the last step is a **display-correlated capture** — change the water level /
+force an alarm on the unit and watch which decoded payload byte moves. The
+firmware gives us what those bytes *mean* once we find them (the alarm-code and
+setpoint tables above), not their positions.
+
+---
+
+## 1. Capture raw IQ for analysis
+
+You need real captures before the decoder can be validated. Based on section 0,
+capture so the signal is **off the DC spike** and **not gain-starved**:
+
+    rtl_sdr -f 868.20M -s 1024000 -g 49 -n $((1024000*300)) uclean_offset.cu8
+
+- `-f 868.20M`  deliberately tune ~150 kHz low. The real carrier (~868.27 MHz,
+  measured) then lands ~+70 kHz from center - clear of the 0 Hz DC spike.
+- `-s 1024k`    1.024 Msps - wide enough for +-38 kHz FSK with room to keep the
+  signal away from DC.
+- `-g 49`       high gain; the first capture was ~15 dB under-driven. Back off if
+  you see clipping (many samples pinned at 0 or 255).
+- `-n ...`      ~300 s => ~5 of the ~62 s exchanges. Increase for more.
+
+The R820T tuner has no hardware offset-tune, so use the frequency offset above
+rather than `-t offset_tune=1`.
+
+You can also let rtl_433 save each detected event, but only with the thresholds
+from section 0 (its defaults miss these bursts):
+
+    rtl_433 -f 868.20M -s 1024k -g 49 -S all \
+      -Y minmax -Y minlevel=-40 -Y minsnr=3
+
+Each `g###_868.20M_1024k.cu8` file is one event (containing the 2-packet
+exchange).
+
+### Analyze in Universal Radio Hacker (URH)
+
+1. Open the `.cu8` in URH (Interpretation tab). Set the sample rate to match
+   the capture (1.024 Msps).
+2. Demodulate as **FSK**. Read the bit/symbol rate off the eye diagram - it
+   should be ~50 kbps (20 us/bit) or ~100 kbps (10 us/bit). This resolves
+   **[U1] data rate**.
+3. Identify the alternating preamble, then the constant **address** bytes that
+   repeat across every packet -> resolves **[U2] address width** and
+   **[U3] address bytes**.
+4. Count the payload bytes between the address and the trailing CRC ->
+   **[U5] payload length**. The last 2 bytes (16-bit) or 1 byte (8-bit) are the
+   CRC -> **[U4] CRC width**.
+5. Verify the CRC: compute crc16(address||payload, 0x1021, 0xFFFF) MSB-first and
+   compare to the trailing bytes. If it matches, [U7] (no whitening) and [U8]
+   (MSB-first bit order) are confirmed too.
+6. Capture the same packet while reading the unit's display to map payload bytes
+   to physical quantities -> **[U6] field semantics**.
+
+These same unknowns may also be recoverable from the firmware-analysis stream:
+the nRF905 CONFIG register the 8051 writes contains RX_AFW (address width),
+RX_PW (payload width), CRC_EN/CRC_MODE (CRC width), and CH_NO/HFREQ (channel),
+and TX_ADDRESS holds the address bytes.
+
+---
+
+## 2. Quick first pass with the flex decoder
+
+Before integrating C, sanity-check demodulation with rtl_433's built-in flex
+decoder (`-X`). Assuming 50 kbps (20 us/bit):
+
+    rtl_433 -f 868.35M -X 'n=uclean1,m=FSK_PCM,s=20,l=20,r=200'
+
+- `m=FSK_PCM`  FSK with NRZ/PCM coding (matches nRF905).
+- `s=20 l=20`  short = long = 20 us/bit (50 kbps). Use `s=10 l=10` for 100 kbps.
+- `r=200`      reset limit ~10 bit periods; ends the short ShockBurst frame.
+
+You can also replay a saved capture instead of live SDR:
+
+    rtl_433 -r g001_868.35M_1024k.cu8 -X 'n=uclean1,m=FSK_PCM,s=20,l=20,r=200'
+
+The flex output prints the raw bitrows. Confirm the preamble/address/payload/CRC
+layout matches the nRF905 frame, then fold the confirmed values into
+`tools/rtl433/uponor_clean1.c`.
+
+---
+
+## 3. Build and test the C decoder
+
+The C decoder must be compiled inside an rtl_433 source checkout.
+
+1. Clone rtl_433 and copy the decoder in:
+
+       git clone https://github.com/merbanan/rtl_433
+       cp tools/rtl433/uponor_clean1.c rtl_433/src/devices/
+
+2. Register it. rtl_433 keeps a central list of decoders:
+   - add `DECL(uponor_clean1)` to `include/rtl_433_devices.h`
+     (in the same block as the other `DECL(...)` entries), and
+   - add `src/devices/uponor_clean1.c` to the device source list in
+     `src/CMakeLists.txt` (and the autotools `Makefile.am` if building that way).
+
+3. Build:
+
+       cd rtl_433 && mkdir -p build && cd build
+       cmake .. && make -j
+
+4. Verify the decoder registered and run it against a capture:
+
+       ./src/rtl_433 -R 0       # lists all decoders; find the Uponor Clean1 number
+       ./src/rtl_433 -r ../../capture.cu8 -R <num> -F json
+
+   The decoder ships with `.disabled = 1` (skeleton), so enable it explicitly
+   with `-R <num>` until it is validated and the protocol number is known.
+
+5. Once validated, output to MQTT for Home Assistant:
+
+       rtl_433 -f 868.35M -R <num> -F "mqtt://localhost:1883,events=uclean1/events"
+
+   Then add an MQTT sensor in Home Assistant pointing at that topic.
+
+---
+
+## 4. State of the decoder / what is still needed
+
+`tools/rtl433/uponor_clean1.c` is a **skeleton**. It compiles and demonstrates
+the full pipeline (preamble search -> address match -> CRC-16 check -> JSON),
+but it has **not** been validated against real RF and ships disabled.
+
+To finish it, resolve the UNKNOWNS (listed in the file header) from captures or
+firmware analysis and edit the corresponding `#define`s / constants:
+
+| Unknown | Symbol in uponor_clean1.c                | Source |
+|---------|------------------------------------------|--------|
+| [U1] data rate     | `short_width`/`long_width` (20 vs 10) | capture eye diagram / CONFIG |
+| [U2] address width | `UCLEAN1_ADDR_BYTES`                  | CONFIG RX_AFW / capture |
+| [U3] address bytes | `uclean1_address[]`                   | TX_ADDRESS / capture |
+| [U4] CRC width     | `UCLEAN1_CRC_BITS`                    | CONFIG CRC_EN/CRC_MODE / capture |
+| [U5] payload length| `UCLEAN1_PAYLOAD_BYTES`               | CONFIG RX_PW / capture |
+| [U6] field meaning | `data_make(...)` + `output_fields[]`  | capture vs unit display |
+| [U7] whitening     | (none assumed)                        | confirm via CRC match |
+| [U8] bit order     | (MSB-first assumed)                   | confirm via CRC match |
+
+Do not invent these values - a wrong address or CRC config silently drops every
+packet, and wrong field scaling produces plausible-but-false readings.

--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -185,55 +185,58 @@ and TX_ADDRESS holds the address bytes.
 ## 2. Quick first pass with the flex decoder
 
 Before integrating C, sanity-check demodulation with rtl_433's built-in flex
-decoder (`-X`). At the measured 100 kbps (10 us/bit):
+decoder (`-X`). The best option is to let the flex demodulator do the Manchester
+decode for you, using the `FSK_MC_ZEROBIT` modulation:
+
+    rtl_433 -f 868.20M -Y minmax \
+      -X 'n=uclean1,m=FSK_MC_ZEROBIT,s=10,r=100,bits>=200,invert'
+
+- `m=FSK_MC_ZEROBIT`  a **demodulator-level** Manchester slicer - it decodes
+  Manchester straight from the pulse timing, so the output is the **decoded
+  bytes**, not the raw on-air bits. This is *not* the `decode_mc` post-filter
+  (see below), which does not work here.
+- `s=10`       the half-bit period is 10 us (one 100 kbps raw chip). The slicer
+  pairs chips into data bits, so rows come out ~326 bits (half of the ~650 raw).
+- `r=100`      reset limit; splits the two packets of an exchange (~19 ms apart).
+- `invert`     the slicer's default polarity is the complement of ours; `invert`
+  makes it match the `01`->1 / `10`->0 convention, so the decoded header prints
+  **verbatim** as `fd 7a ba ba ba 83 ...`.
+- `-Y minmax`  **selects the FSK peak detector.** Without it the default detector
+  fragments the weaker (far-unit) packet. With it, a 4-event replay of
+  `uclean_offset.cu8` yields all 8 packets (4 events x near+far) - **full recall**.
+- `bits>=200`  drops the noise rows. Real decoded packets are ~320-330 bits.
+
+`FSK_MC_ZEROBIT` locks its phase on a leading zero bit, so an occasional row is
+off by one bit - just search for `fd 7a` (as the C decoder does) rather than
+assuming byte 0 is the header. Replay a saved capture instead of live SDR:
+
+    rtl_433 -r uclean_offset.cu8 -s 1024k -Y minmax \
+      -X 'n=uclean1,m=FSK_MC_ZEROBIT,s=10,r=100,bits>=200,invert'
+
+### Seeing the raw on-air bits instead
+
+If you want the raw (still Manchester-*encoded*) stream to inspect by eye
+(`01`->1, `10`->0), use `FSK_PCM` at the full 100 kbps line rate:
 
     rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
 
-- `m=FSK_PCM`  FSK with NRZ/PCM coding. This prints the **raw on-air bits**,
-  i.e. the Manchester-*encoded* stream - decode it by eye (raw `01`->1, `10`->0)
-  or use the C decoder for the real payload.
-- `s=10 l=10`  short = long = 10 us/bit (100 kbps).
-- `r=100`      reset limit; ends a packet after ~10 bit periods with no
-  transition. Manchester guarantees a transition every <=2 bits, so this keeps a
-  packet whole yet still splits the two packets of an exchange (~19 ms apart).
-- `-Y minmax`  **selects the FSK peak detector.** Without it the default detector
-  fragments the weaker (far-unit) packet into several short rows. With it, a
-  4-event replay of `uclean_offset.cu8` yields 8 clean ~650-bit packets
-  (4 events x near+far), which is what you want.
-- `bits>=400`  drops the noise rows. Real packets are ~635-654 raw bits; stray
-  detections are <100, so this filter removes them without touching real frames.
+Here rows are ~635-654 raw bits and `bits>=400` filters the noise. You can also
+add `,preamble={32}55599566` to strip the leading `0xBA` run and align rows to the
+header - that value is `fd 7a` in the raw encoded domain (`fd 7a` = `11111101
+01111010`, encode `1`->`01`/`0`->`10` => `0x5559 0x9566`). But keep the preamble
+**optional**: it is an exact match over 32 raw bits, so a single noise-flipped bit
+in the sync drops the whole packet and you can lose the weaker packet of an
+exchange. `FSK_MC_ZEROBIT` above is the better choice - it decodes natively and
+keeps full recall.
 
-Optional - align rows to the header with a preamble anchor:
+### Why not `decode_mc`?
 
-    rtl_433 -f 868.20M -Y minmax \
-      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
-
-`preamble={32}55599566` is the **same `fd 7a` sync the C decoder anchors on**, but
-expressed in the raw (Manchester-*encoded*) domain so it can match the on-air
-bits. Decoded `fd 7a` = `11111101 01111010`; encode each bit (`1`->`01`, `0`->`10`)
-and you get raw `0x5559 0x9566`. It strips the leading `0xBA` run so every row
-begins right at the header.
-
-**But keep the preamble optional.** The flex `preamble` is an *exact* match over
-all 32 raw bits, in the noisier raw domain (each decoded bit is two raw bits), so a
-single noise-flipped bit in the sync drops the **whole** packet. On a live capture
-that intermittently loses the weaker (far-unit) packet of an exchange - you get one
-message instead of two. The C decoder avoids this by Manchester-decoding with
-tolerance *first* and only then bit-searching for `fd 7a`, so a stray bit costs
-alignment, not the frame. Use `bits>=400` alone when you want to catch **every**
-message; add `preamble` only when you want tidy aligned rows from a clean signal.
-
-You can replay a saved capture instead of live SDR (match the capture rate):
-
-    rtl_433 -r uclean_offset.cu8 -s 1024k -Y minmax \
-      -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
-
-Note: the flex `decode_mc` (native Manchester) option does **not** work here - it
-aborts at the first Manchester violation and only tries phase 0, so these
-phase-offset, slightly-noisy packets collapse to empty rows. That is exactly why
-`tools/rtl433/uponor_clean1.c` does its own violation-tolerant, two-phase
-Manchester pass. Use the C decoder (`-R <num>`) for the actual decoded payload;
-use this flex command only to confirm clean bit recovery.
+The flex `decode_mc` (a post-filter on already-sliced NRZ bits, *not* a
+modulation) does **not** work here: it aborts at the first Manchester violation
+and only tries phase 0, so these phase-offset, slightly-noisy packets collapse to
+empty rows. `FSK_MC_ZEROBIT` avoids that by working at the demodulator/timing
+level. For the fully validated payload (with the violation-tolerant two-phase
+pass and CRC gating) use the C decoder (`-R <num>`).
 
 ---
 

--- a/tools/ghidra/DumpBytes.java
+++ b/tools/ghidra/DumpBytes.java
@@ -1,0 +1,31 @@
+// Dump raw bytes from flash at each given address range.
+// Run via: tools/analyze.sh DumpBytes.java <outfile> <hexaddr:len> [<hexaddr:len>...]
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.Address;
+import java.io.PrintWriter;
+
+public class DumpBytes extends GhidraScript {
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) { println("usage: DumpBytes.java <outfile> <hex:len>..."); return; }
+        PrintWriter out = new PrintWriter(args[0]);
+        for (int i = 1; i < args.length; i++) {
+            String[] p = args[i].split(":");
+            long off = Long.parseLong(p[0].replaceFirst("^0x", ""), 16);
+            int len = Integer.parseInt(p[1]);
+            Address a = toAddr(off);
+            StringBuilder hex = new StringBuilder();
+            StringBuilder asc = new StringBuilder();
+            for (int k = 0; k < len; k++) {
+                int b;
+                try { b = getByte(a.add(k)) & 0xff; }
+                catch (Exception e) { hex.append("?? "); asc.append('.'); continue; }
+                hex.append(String.format("%02x ", b));
+                asc.append(b >= 0x20 && b < 0x7f ? (char) b : '.');
+            }
+            out.printf("0x%04x (%d bytes): %s |%s|%n", off, len, hex.toString().trim(), asc);
+        }
+        out.close();
+        println("wrote " + args[0]);
+    }
+}

--- a/tools/ghidra/FindRefsInRange.java
+++ b/tools/ghidra/FindRefsInRange.java
@@ -1,0 +1,46 @@
+// List every instruction that references a data address in [lo, hi], grouped by
+// the function it lives in. Useful for finding the consumers of a RAM buffer or
+// a parameter table (who reads the SPI receive buffer, who reads a setpoint).
+//
+// Run via: tools/analyze.sh FindRefsInRange.java <outfile> <lohex> <hihex>
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.InstructionIterator;
+import ghidra.program.model.symbol.Reference;
+import java.io.PrintWriter;
+
+public class FindRefsInRange extends GhidraScript {
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 3) {
+            println("usage: FindRefsInRange.java <outfile> <lohex> <hihex>");
+            return;
+        }
+        PrintWriter out = new PrintWriter(args[0]);
+        long lo = Long.parseLong(args[1].replaceFirst("^0x", ""), 16);
+        long hi = Long.parseLong(args[2].replaceFirst("^0x", ""), 16);
+        out.printf("refs into [0x%x, 0x%x]%n", lo, hi);
+
+        InstructionIterator it = currentProgram.getListing().getInstructions(true);
+        while (it.hasNext()) {
+            Instruction ins = it.next();
+            for (Reference r : ins.getReferencesFrom()) {
+                Address to = r.getToAddress();
+                if (to == null || !to.isMemoryAddress()) continue;
+                long o = to.getOffset();
+                if (o < lo || o > hi) continue;
+                Function f = getFunctionContaining(ins.getAddress());
+                out.printf("  0x%-6s %-6s -> 0x%-4x  [%s] %s%n",
+                        ins.getAddress().toString(),
+                        r.getReferenceType().getName(),
+                        o,
+                        f != null ? f.getName() : "?",
+                        ins.toString());
+            }
+        }
+        out.close();
+        println("wrote " + args[0]);
+    }
+}

--- a/tools/ghidra/ForceDecompile.java
+++ b/tools/ghidra/ForceDecompile.java
@@ -1,0 +1,62 @@
+// Force-disassemble and create a function at each given address (even inside a
+// code gap the auto-analyzer skipped), then decompile it to a file. Also dumps
+// the HCS08 interrupt/reset vector table (0xFFC0-0xFFFF) so ISR entries can be
+// matched to their vectors.
+//
+// Run via: tools/analyze.sh ForceDecompile.java <outfile> <hexaddr> [<hexaddr>...]
+import ghidra.app.script.GhidraScript;
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.mem.MemoryBlock;
+import java.io.PrintWriter;
+
+public class ForceDecompile extends GhidraScript {
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) {
+            println("usage: ForceDecompile.java <outfile> <hexaddr> [<hexaddr>...]");
+            return;
+        }
+        PrintWriter out = new PrintWriter(args[0]);
+
+        // Dump vector table: 16-bit big-endian pointers at 0xFFC0..0xFFFE.
+        out.println("########## VECTOR TABLE 0xFFC0-0xFFFE ##########");
+        for (long a = 0xFFC0L; a <= 0xFFFEL; a += 2) {
+            Address va = toAddr(a);
+            try {
+                int hi = getByte(va) & 0xff;
+                int lo = getByte(va.add(1)) & 0xff;
+                out.printf("  vec @0x%04x -> 0x%04x%n", a, (hi << 8) | lo);
+            } catch (Exception e) {
+                out.printf("  vec @0x%04x -> <unreadable>%n", a);
+            }
+        }
+        out.println();
+
+        DecompInterface di = new DecompInterface();
+        di.openProgram(currentProgram);
+
+        for (int i = 1; i < args.length; i++) {
+            long off = Long.parseLong(args[i].replaceFirst("^0x", ""), 16);
+            Address addr = toAddr(off);
+            Function f = getFunctionContaining(addr);
+            if (f == null) {
+                disassemble(addr);
+                f = createFunction(addr, "FORCED_" + Long.toHexString(off));
+            }
+            out.println("########## 0x" + Long.toHexString(off) + " -> "
+                    + (f != null ? f.getName() + " @ " + f.getEntryPoint() : "<no func>")
+                    + " ##########");
+            if (f != null) {
+                DecompileResults res = di.decompileFunction(f, 60, monitor);
+                out.println((res != null && res.getDecompiledFunction() != null)
+                        ? res.getDecompiledFunction().getC() : "<decompile failed>");
+            }
+            out.println();
+        }
+        out.close();
+        println("wrote " + args[0]);
+    }
+}

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -60,24 +60,25 @@ Because [U5]/[U6] are open, this decoder emits the constant header plus the raw
 Manchester-decoded payload as a hex string, so captures can be correlated with
 the display. It ships disabled until the fields and CRC are pinned down.
 
-Flex-decoder equivalent for a first capture pass (raw on-air bits, Manchester by
-eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike; -Y minmax
-selects the FSK peak detector (otherwise weak packets fragment) and bits>=400
-drops the noise rows (real packets are ~650 raw bits):
+Flex-decoder equivalent for a first capture pass. Tune ~150 kHz low so the
+carrier lands off the RTL-SDR DC spike; -Y minmax selects the FSK peak detector
+(otherwise the weak far-unit packet fragments). Best option - let the flex
+demodulator do the Manchester decode, so the payload comes out readable:
+  rtl_433 -f 868.20M -Y minmax \
+    -X 'n=uclean1,m=FSK_MC_ZEROBIT,s=10,r=100,bits>=200,invert'
+FSK_MC_ZEROBIT is a demod-LEVEL Manchester slicer (decodes from pulse timing),
+so s=10 is the half-bit period and the output is the DECODED bytes (~326 bits,
+half of ~650). "invert" makes it match our raw 01->1 / 10->0 convention, so the
+fd 7a ba ba ba 83 header prints verbatim. Full recall (all 8 packets of a 4-event
+replay). Its phase lock assumes a leading zero bit, so a row may be off by one
+bit - just search for fd7a as this decoder does. NOTE this is NOT the same as the
+"decode_mc" post-filter, which aborts at the first Manchester violation and only
+tries phase 0, so on these phase-offset, slightly-noisy packets it collapses to
+empty rows - that filter is unusable here, which is why this C decoder rolls its
+own tolerant, two-phase pass.
+To instead see the RAW on-air bits (Manchester still encoded, decode by eye
+01->1/10->0), use FSK_PCM at the full 100 kbps line rate:
   rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
-Optionally add ,preamble={32}55599566 to strip the leading 0xBA run and align
-every row to the fd7a header - that value is the SAME sync this decoder anchors
-on, in the raw (Manchester-encoded) domain: decoded fd 7a = 11111101 01111010,
-encode 1->01/0->10 => raw 0x5559 0x9566. But keep it OPTIONAL: the flex preamble
-is an EXACT match over all 32 raw bits, so a single noise-flipped bit in the sync
-drops the whole packet - which is why on a live capture it can miss the weaker
-(far-unit) packet of an exchange. This C decoder avoids that by Manchester-
-decoding with tolerance FIRST and only then bit-searching for fd7a, so a stray
-bit costs alignment, not the whole frame. Use bits>=400 (no preamble) when you
-want to see every message; add preamble only when you want tidy aligned rows.
-The flex "decode_mc" option is NOT usable here: it aborts at the first Manchester
-violation and only tries phase 0, so these phase-offset, slightly-noisy packets
-collapse to empty rows - which is exactly why this C decoder rolls its own pass.
 */
 
 #include "decoder.h"

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -1,0 +1,255 @@
+/** @file
+    Uponor Clean 1 wastewater treatment unit - 868.35 MHz telemetry link.
+
+    Copyright (C) 2026 Andy B
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+/**
+Uponor Clean 1 - inner/outer unit radio link.
+
+The Clean 1 links the outer (tank) unit and the inner (indoor display) unit.
+U1 on the PCB is a Nordic nRF9E5 (nRF905 transceiver + 8051 MCU). The radio PHY
+is nRF905: GFSK, 868 MHz band. Everything below was measured from real RTL-SDR
+captures (see docs/rtl433.md, "Empirical results"), NOT assumed from the
+datasheet - and several datasheet-default assumptions turned out to be wrong.
+
+CONFIRMED from captures
+-----------------------
+- Carrier   : ~868.3 MHz (a specific nRF905 channel).
+- Modulation: FSK, deviation ~+-38 kHz.
+- LINE RATE : 100 kbps (10 us/bit), NOT the nRF905 50 kbps default.
+- CODING    : the payload is MANCHESTER-encoded (the nRF9E5 firmware does this
+              in software - the radio itself is NRZ). Raw 100 kbps line =>
+              ~50 kbps of Manchester data, ~40 bytes/packet. This is the single
+              most important correction over the old skeleton, which assumed
+              plain NRZ.
+              Convention observed: raw "01" -> 1, raw "10" -> 0.
+- FRAMING   : each transmit event (every ~62 s) is a TWO-packet exchange -
+              packet A (~6.2 ms) then a ~19 ms gap then packet B (~6.6 ms), with
+              very different RSSI = the near/far units answering each other.
+- SYNC/HDR  : after a repeating 0xBA run, every Manchester-decoded packet begins
+              with a constant header:  fd 7a  ba ba ba  83  <payload...>.
+              The 0xfd 0x7a pair is used here as the frame anchor.
+- PAYLOAD   : ~30 bytes after the header. Across consecutive events the payload
+              is near-static (3 of 4 events were byte-identical), i.e. it is
+              slowly-changing telemetry, not a counter/nonce.
+
+STILL UNKNOWN (do not invent)
+-----------------------------
+  [U5] exact payload length / where the payload ends and any CRC begins.
+  [U4] CRC: nRF905 hardware CRC covers the *on-air* (pre-Manchester) bytes, so it
+       is not visible in the Manchester-decoded stream; there may additionally be
+       an application checksum inside the payload. Unconfirmed - not gated on.
+  [U6] field semantics: which decoded byte is water level / temperature / phase /
+       alarm code / pump state. The MC9S08 firmware was checked (see docs/rtl433.md
+       "0b. What the MC9S08 firmware says") and the payload byte layout is NOT in
+       it: the CPU is only an SPI *slave* on a custom MC9S08<->8051 message bus, so
+       the on-air framing and byte packing are done by the nRF9E5's 8051, not the
+       CPU. The firmware does give the decode *targets* - the alarm code table
+       (0x02 no-radio, 0x28 compressor, 0x29-0x2D MV1-5, 0x2F EEPROM error, ...)
+       and the phase names, which the payload codes should index into. So [U6] must
+       be resolved by a display-correlated capture: change the level / force an
+       alarm and watch which decoded payload byte moves.
+
+Because [U5]/[U6] are open, this decoder emits the constant header plus the raw
+Manchester-decoded payload as a hex string, so captures can be correlated with
+the display. It ships disabled until the fields and CRC are pinned down.
+
+Flex-decoder equivalent for a first capture pass (100 kbps, then Manchester by
+eye): rtl_433 -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100'
+*/
+
+#include "decoder.h"
+
+// Raw line rate 100 kbps => 10 us/bit at the PCM demod.
+#define UCLEAN1_BIT_US 10
+
+// Manchester-decoded header anchor (see notes above): fd 7a precedes the packet.
+static uint8_t const uclean1_sync[] = {0xfd, 0x7a};
+
+// Conservative bounds on the Manchester-decoded packet (bytes).
+#define UCLEAN1_MIN_BYTES 20
+#define UCLEAN1_MAX_BYTES 64
+
+// Read bit `i` (MSB-first) from a packed byte buffer.
+static inline int uclean1_bit(uint8_t const *buf, unsigned i)
+{
+    return (buf[i >> 3] >> (7 - (i & 7))) & 1;
+}
+
+// Manchester-decode `nbits` raw bits from `raw` (packed) starting at raw-bit
+// `start`, convention raw 01->1, raw 10->0. Writes packed decoded bits to `out`.
+// Returns number of decoded bits; *illegal counts 00/11 violations.
+static unsigned uclean1_manchester(uint8_t const *raw, unsigned start,
+        unsigned nbits, uint8_t *out, unsigned out_cap_bits, unsigned *illegal)
+{
+    unsigned n = 0;
+    *illegal = 0;
+    for (unsigned i = start; i + 1 < nbits && n < out_cap_bits; i += 2) {
+        int a = uclean1_bit(raw, i);
+        int b = uclean1_bit(raw, i + 1);
+        int d;
+        if (a == 0 && b == 1)
+            d = 1;              // 01 -> 1
+        else if (a == 1 && b == 0)
+            d = 0;              // 10 -> 0
+        else {                  // 00 / 11 : Manchester violation
+            (*illegal)++;
+            d = 0;
+        }
+        if (d)
+            out[n >> 3] |= (uint8_t)(1 << (7 - (n & 7)));
+        else
+            out[n >> 3] &= (uint8_t)~(1 << (7 - (n & 7)));
+        n++;
+    }
+    return n;
+}
+
+// Bit-level search for `pat` (pat_bits long) in packed `buf` of `nbits`.
+// Returns the bit index of the match, or nbits if not found.
+static unsigned uclean1_bitsearch(uint8_t const *buf, unsigned nbits,
+        uint8_t const *pat, unsigned pat_bits)
+{
+    if (pat_bits > nbits)
+        return nbits;
+    for (unsigned off = 0; off + pat_bits <= nbits; ++off) {
+        unsigned k = 0;
+        for (; k < pat_bits; ++k) {
+            if (uclean1_bit(buf, off + k) != uclean1_bit(pat, k))
+                break;
+        }
+        if (k == pat_bits)
+            return off;
+    }
+    return nbits;
+}
+
+static int uponor_clean1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
+{
+    int ret = DECODE_ABORT_EARLY;
+
+    for (unsigned row = 0; row < bitbuffer->num_rows; ++row) {
+        unsigned raw_bits = bitbuffer->bits_per_row[row];
+
+        // A ~6.5 ms Manchester packet at 100 kbps is ~650 raw bits.
+        if (raw_bits < UCLEAN1_MIN_BYTES * 16) {
+            ret = DECODE_ABORT_LENGTH;
+            continue;
+        }
+
+        // Copy the raw row out as packed bytes.
+        uint8_t raw[128] = {0};
+        unsigned copy_bits = raw_bits > sizeof(raw) * 8 ? sizeof(raw) * 8 : raw_bits;
+        bitbuffer_extract_bytes(bitbuffer, row, 0, raw, copy_bits);
+
+        // Manchester-decode both bit-phase alignments; keep the cleaner one.
+        uint8_t dec[UCLEAN1_MAX_BYTES + 4] = {0};
+        uint8_t best[sizeof(dec)] = {0};
+        unsigned best_bits = 0, best_ill = ~0u;
+        for (unsigned phase = 0; phase < 2; ++phase) {
+            unsigned ill = 0;
+            unsigned nb = uclean1_manchester(raw, phase, copy_bits, dec,
+                    sizeof(dec) * 8, &ill);
+            if (ill < best_ill) {
+                best_ill = ill;
+                best_bits = nb;
+                memcpy(best, dec, sizeof(dec));
+            }
+        }
+
+        // A genuine Manchester packet has very few violations. Random noise
+        // demodulated at 100 kbps sits near 50%. Require < ~15%.
+        if (best_bits < UCLEAN1_MIN_BYTES * 8
+                || best_ill * 100 > (best_bits / 2) * 15) {
+            ret = DECODE_ABORT_EARLY;
+            continue;
+        }
+
+        // Find the fd 7a frame anchor in the decoded stream.
+        unsigned pos = uclean1_bitsearch(best, best_bits,
+                uclean1_sync, sizeof(uclean1_sync) * 8);
+        if (pos >= best_bits) {
+            decoder_log(decoder, 2, __func__, "sync fd7a not found");
+            ret = DECODE_ABORT_EARLY;
+            continue;
+        }
+
+        // Header = fd 7a ba ba ba 83  (6 bytes = 48 bits); payload follows.
+        unsigned hdr_bits = 6 * 8;
+        unsigned payload_start = pos + hdr_bits;
+        if (payload_start + UCLEAN1_MIN_BYTES * 8 > best_bits) {
+            ret = DECODE_ABORT_LENGTH;
+            continue;
+        }
+
+        // Byte-align header + payload for output. Extract up to what we have.
+        unsigned avail_bits = best_bits - pos;
+        unsigned avail_bytes = avail_bits / 8;
+        if (avail_bytes > UCLEAN1_MAX_BYTES)
+            avail_bytes = UCLEAN1_MAX_BYTES;
+        uint8_t frame[UCLEAN1_MAX_BYTES] = {0};
+        for (unsigned i = 0; i < avail_bytes; ++i) {
+            uint8_t v = 0;
+            for (unsigned k = 0; k < 8; ++k)
+                v = (uint8_t)((v << 1) | uclean1_bit(best, pos + i * 8 + k));
+            frame[i] = v;
+        }
+
+        // frame[0..5] = header, frame[6..] = payload.
+        unsigned payload_len = avail_bytes > 6 ? avail_bytes - 6 : 0;
+
+        char header_str[6 * 2 + 1];
+        for (unsigned i = 0; i < 6; ++i)
+            snprintf(header_str + i * 2, 3, "%02x", frame[i]);
+
+        char payload_str[UCLEAN1_MAX_BYTES * 2 + 1];
+        for (unsigned i = 0; i < payload_len; ++i)
+            snprintf(payload_str + i * 2, 3, "%02x", frame[6 + i]);
+
+        /* clang-format off */
+        data_t *data = data_make(
+                "model",        "",             DATA_STRING, "Uponor-Clean1",
+                "header",       "Header",       DATA_STRING, header_str,
+                "payload",      "Payload",      DATA_STRING, payload_str,
+                "payload_len",  "Payload bytes",DATA_INT,    (int)payload_len,
+                "mc_illegal",   "MC violations",DATA_INT,    (int)best_ill,
+                NULL);
+        /* clang-format on */
+        decoder_output_data(decoder, data);
+        return 1;
+    }
+
+    return ret;
+}
+
+static char const *const uponor_clean1_output_fields[] = {
+        "model",
+        "header",
+        "payload",
+        "payload_len",
+        "mc_illegal",
+        // Real sensor fields go here once [U6] is resolved, e.g.:
+        // "level_pct", "temperature_C", "phase", "alarm", "pump_on",
+        NULL,
+};
+
+// 100 kbps line rate => 10 us/bit. FSK_PULSE_PCM with short==long==bit period.
+// reset_limit ends the packet after a run with no transition; Manchester
+// guarantees a transition at least every 2 bits, so ~100 us (10 bits) is safe
+// and still splits the two packets of an exchange (~19 ms apart) into rows.
+r_device const uponor_clean1 = {
+        .name        = "Uponor Clean 1 wastewater unit (nRF905, 868 MHz, 100kbps Manchester) [UNVERIFIED]",
+        .modulation  = FSK_PULSE_PCM,
+        .short_width = UCLEAN1_BIT_US,
+        .long_width  = UCLEAN1_BIT_US,
+        .reset_limit = 100,
+        .decode_fn   = &uponor_clean1_decode,
+        .disabled    = 1,   // keep disabled until CRC + fields are validated
+        .fields      = uponor_clean1_output_fields,
+};

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -71,11 +71,13 @@ so s=10 is the half-bit period and the output is the DECODED bytes (~326 bits,
 half of ~650). "invert" makes it match our raw 01->1 / 10->0 convention, so the
 fd 7a ba ba ba 83 header prints verbatim. Full recall (all 8 packets of a 4-event
 replay). Its phase lock assumes a leading zero bit, so a row may be off by one
-bit - just search for fd7a as this decoder does. NOTE this is NOT the same as the
-"decode_mc" post-filter, which aborts at the first Manchester violation and only
-tries phase 0, so on these phase-offset, slightly-noisy packets it collapses to
-empty rows - that filter is unusable here, which is why this C decoder rolls its
-own tolerant, two-phase pass.
+bit - just search for fd7a as this decoder does. This C decoder uses the same
+demod (FSK_PULSE_MANCHESTER_ZEROBIT), so the framework hands us the already
+Manchester-decoded bytes and we simply anchor on fd7a.
+NOTE the demod-level slicer is NOT the same as the "decode_mc" post-filter, which
+aborts at the first Manchester violation and only tries phase 0, so on these
+phase-offset, slightly-noisy packets it collapses to empty rows - that filter is
+unusable here.
 To instead see the RAW on-air bits (Manchester still encoded, decode by eye
 01->1/10->0), use FSK_PCM at the full 100 kbps line rate:
   rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
@@ -83,7 +85,8 @@ To instead see the RAW on-air bits (Manchester still encoded, decode by eye
 
 #include "decoder.h"
 
-// Raw line rate 100 kbps => 10 us/bit at the PCM demod.
+// Raw line rate 100 kbps => 10 us/bit; the Manchester half-bit is 10 us, so the
+// ZEROBIT slicer uses short==long==10 us.
 #define UCLEAN1_BIT_US 10
 
 // Manchester-decoded header anchor (see notes above): fd 7a precedes the packet.
@@ -93,140 +96,58 @@ static uint8_t const uclean1_sync[] = {0xfd, 0x7a};
 #define UCLEAN1_MIN_BYTES 20
 #define UCLEAN1_MAX_BYTES 64
 
-// Read bit `i` (MSB-first) from a packed byte buffer.
-static inline int uclean1_bit(uint8_t const *buf, unsigned i)
-{
-    return (buf[i >> 3] >> (7 - (i & 7))) & 1;
-}
-
-// Manchester-decode `nbits` raw bits from `raw` (packed) starting at raw-bit
-// `start`, convention raw 01->1, raw 10->0. Writes packed decoded bits to `out`.
-// Returns number of decoded bits; *illegal counts 00/11 violations.
-//
-// rtl_433 does ship bitbuffer_manchester_decode(), which uses this same
-// convention (it emits the second bit of each pair). We deliberately don't use
-// it here: it aborts at the FIRST Manchester violation and decodes a single
-// phase alignment. Real captures of this link carry ~3-4% illegal pairs (noise)
-// at an unknown bit phase, so we instead tolerate violations, count them as a
-// quality metric, and let the caller try both phases and keep the cleaner one.
-static unsigned uclean1_manchester(uint8_t const *raw, unsigned start,
-        unsigned nbits, uint8_t *out, unsigned out_cap_bits, unsigned *illegal)
-{
-    unsigned n = 0;
-    *illegal = 0;
-    for (unsigned i = start; i + 1 < nbits && n < out_cap_bits; i += 2) {
-        int a = uclean1_bit(raw, i);
-        int b = uclean1_bit(raw, i + 1);
-        int d;
-        if (a == 0 && b == 1)
-            d = 1;              // 01 -> 1
-        else if (a == 1 && b == 0)
-            d = 0;              // 10 -> 0
-        else {                  // 00 / 11 : Manchester violation
-            (*illegal)++;
-            d = 0;
-        }
-        if (d)
-            out[n >> 3] |= (uint8_t)(1 << (7 - (n & 7)));
-        else
-            out[n >> 3] &= (uint8_t)~(1 << (7 - (n & 7)));
-        n++;
-    }
-    return n;
-}
-
-// Bit-level search for `pat` (pat_bits long) in packed `buf` of `nbits`.
-// Returns the bit index of the match, or nbits if not found.
-static unsigned uclean1_bitsearch(uint8_t const *buf, unsigned nbits,
-        uint8_t const *pat, unsigned pat_bits)
-{
-    if (pat_bits > nbits)
-        return nbits;
-    for (unsigned off = 0; off + pat_bits <= nbits; ++off) {
-        unsigned k = 0;
-        for (; k < pat_bits; ++k) {
-            if (uclean1_bit(buf, off + k) != uclean1_bit(pat, k))
-                break;
-        }
-        if (k == pat_bits)
-            return off;
-    }
-    return nbits;
-}
-
 static int uponor_clean1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 {
     int ret = DECODE_ABORT_EARLY;
 
     for (unsigned row = 0; row < bitbuffer->num_rows; ++row) {
-        unsigned raw_bits = bitbuffer->bits_per_row[row];
+        unsigned row_bits = bitbuffer->bits_per_row[row];
 
-        // A ~6.5 ms Manchester packet at 100 kbps is ~650 raw bits.
-        if (raw_bits < UCLEAN1_MIN_BYTES * 16) {
+        // FSK_PULSE_MANCHESTER_ZEROBIT already Manchester-decoded the row, so a
+        // packet is header(6) + ~30 payload bytes of DECODED data.
+        if (row_bits < UCLEAN1_MIN_BYTES * 8) {
             ret = DECODE_ABORT_LENGTH;
             continue;
         }
 
-        // Copy the raw row out as packed bytes.
-        uint8_t raw[128] = {0};
-        unsigned copy_bits = raw_bits > sizeof(raw) * 8 ? sizeof(raw) * 8 : raw_bits;
-        bitbuffer_extract_bytes(bitbuffer, row, 0, raw, copy_bits);
-
-        // Manchester-decode both bit-phase alignments; keep the cleaner one.
-        uint8_t dec[UCLEAN1_MAX_BYTES + 4] = {0};
-        uint8_t best[sizeof(dec)] = {0};
-        unsigned best_bits = 0, best_ill = ~0u;
-        for (unsigned phase = 0; phase < 2; ++phase) {
-            unsigned ill = 0;
-            unsigned nb = uclean1_manchester(raw, phase, copy_bits, dec,
-                    sizeof(dec) * 8, &ill);
-            if (ill < best_ill) {
-                best_ill = ill;
-                best_bits = nb;
-                memcpy(best, dec, sizeof(dec));
-            }
-        }
-
-        // A genuine Manchester packet has very few violations. Random noise
-        // demodulated at 100 kbps sits near 50%. Require < ~15%.
-        if (best_bits < UCLEAN1_MIN_BYTES * 8
-                || best_ill * 100 > (best_bits / 2) * 15) {
-            ret = DECODE_ABORT_EARLY;
-            continue;
-        }
-
-        // Find the fd 7a frame anchor in the decoded stream.
-        unsigned pos = uclean1_bitsearch(best, best_bits,
+        // The ZEROBIT slicer phase-locks on a leading zero bit, so the fd 7a
+        // anchor can land at any bit offset - search for it. Its output polarity
+        // depends on which Manchester convention matched, so if the anchor is not
+        // found, invert the whole buffer and try once more (then restore).
+        unsigned pos = bitbuffer_search(bitbuffer, row, 0,
                 uclean1_sync, sizeof(uclean1_sync) * 8);
-        if (pos >= best_bits) {
+        int inverted = 0;
+        if (pos >= row_bits) {
+            bitbuffer_invert(bitbuffer);
+            inverted = 1;
+            pos = bitbuffer_search(bitbuffer, row, 0,
+                    uclean1_sync, sizeof(uclean1_sync) * 8);
+        }
+        if (pos >= row_bits) {
+            if (inverted)
+                bitbuffer_invert(bitbuffer); // restore for the next row
             decoder_log(decoder, 2, __func__, "sync fd7a not found");
             ret = DECODE_ABORT_EARLY;
             continue;
         }
 
         // Header = fd 7a ba ba ba 83  (6 bytes = 48 bits); payload follows.
-        unsigned hdr_bits = 6 * 8;
-        unsigned payload_start = pos + hdr_bits;
-        if (payload_start + UCLEAN1_MIN_BYTES * 8 > best_bits) {
+        if (pos + (6 + UCLEAN1_MIN_BYTES) * 8 > row_bits) {
+            if (inverted)
+                bitbuffer_invert(bitbuffer);
             ret = DECODE_ABORT_LENGTH;
             continue;
         }
 
-        // Byte-align header + payload for output. Extract up to what we have.
-        unsigned avail_bits = best_bits - pos;
-        unsigned avail_bytes = avail_bits / 8;
+        // Byte-align header + payload from the anchor. Extract what we have.
+        unsigned avail_bytes = (row_bits - pos) / 8;
         if (avail_bytes > UCLEAN1_MAX_BYTES)
             avail_bytes = UCLEAN1_MAX_BYTES;
         uint8_t frame[UCLEAN1_MAX_BYTES] = {0};
-        for (unsigned i = 0; i < avail_bytes; ++i) {
-            uint8_t v = 0;
-            for (unsigned k = 0; k < 8; ++k)
-                v = (uint8_t)((v << 1) | uclean1_bit(best, pos + i * 8 + k));
-            frame[i] = v;
-        }
+        bitbuffer_extract_bytes(bitbuffer, row, pos, frame, avail_bytes * 8);
 
         // frame[0..5] = header, frame[6..] = payload.
-        unsigned payload_len = avail_bytes > 6 ? avail_bytes - 6 : 0;
+        unsigned payload_len = avail_bytes - 6;
 
         char header_str[6 * 2 + 1];
         for (unsigned i = 0; i < 6; ++i)
@@ -242,7 +163,6 @@ static int uponor_clean1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 "header",       "Header",       DATA_STRING, header_str,
                 "payload",      "Payload",      DATA_STRING, payload_str,
                 "payload_len",  "Payload bytes",DATA_INT,    (int)payload_len,
-                "mc_illegal",   "MC violations",DATA_INT,    (int)best_ill,
                 NULL);
         /* clang-format on */
         decoder_output_data(decoder, data);
@@ -257,19 +177,20 @@ static char const *const uponor_clean1_output_fields[] = {
         "header",
         "payload",
         "payload_len",
-        "mc_illegal",
         // Real sensor fields go here once [U6] is resolved, e.g.:
         // "level_pct", "temperature_C", "phase", "alarm", "pump_on",
         NULL,
 };
 
-// 100 kbps line rate => 10 us/bit. FSK_PULSE_PCM with short==long==bit period.
-// reset_limit ends the packet after a run with no transition; Manchester
-// guarantees a transition at least every 2 bits, so ~100 us (10 bits) is safe
-// and still splits the two packets of an exchange (~19 ms apart) into rows.
+// 100 kbps line rate => 10 us Manchester half-bit. FSK_PULSE_MANCHESTER_ZEROBIT
+// slices on that half-bit period (short==long==10 us) and hands back the decoded
+// data bits directly. reset_limit ends the packet after a gap with no
+// transition; Manchester guarantees a transition at least every 2 half-bits, so
+// ~100 us is safe and still splits the two packets of an exchange (~19 ms apart)
+// into separate rows.
 r_device const uponor_clean1 = {
         .name        = "Uponor Clean 1 wastewater unit (nRF905, 868 MHz, 100kbps Manchester) [UNVERIFIED]",
-        .modulation  = FSK_PULSE_PCM,
+        .modulation  = FSK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = UCLEAN1_BIT_US,
         .long_width  = UCLEAN1_BIT_US,
         .reset_limit = 100,

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -60,9 +60,14 @@ Because [U5]/[U6] are open, this decoder emits the constant header plus the raw
 Manchester-decoded payload as a hex string, so captures can be correlated with
 the display. It ships disabled until the fields and CRC are pinned down.
 
-Flex-decoder equivalent for a first capture pass (100 kbps, then Manchester by
-eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike (see
-docs/rtl433.md): rtl_433 -f 868.20M -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100'
+Flex-decoder equivalent for a first capture pass (raw on-air bits, Manchester by
+eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike; -Y minmax
+selects the FSK peak detector (otherwise weak packets fragment) and bits>=400
+drops the noise rows (real packets are ~650 raw bits):
+  rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
+The flex "decode_mc" option is NOT usable here: it aborts at the first Manchester
+violation and only tries phase 0, so these phase-offset, slightly-noisy packets
+collapse to empty rows - which is exactly why this C decoder rolls its own pass.
 */
 
 #include "decoder.h"

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -63,8 +63,12 @@ the display. It ships disabled until the fields and CRC are pinned down.
 Flex-decoder equivalent for a first capture pass (raw on-air bits, Manchester by
 eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike; -Y minmax
 selects the FSK peak detector (otherwise weak packets fragment) and bits>=400
-drops the noise rows (real packets are ~650 raw bits):
-  rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
+drops the noise rows (real packets are ~650 raw bits). preamble is the SAME fd7a
+sync this decoder anchors on, expressed in the raw (Manchester-encoded) domain:
+decoded fd 7a = 11111101 01111010, encode 1->01/0->10 => raw 0x5559 0x9566. It
+aligns every packet to the same start (all 8 in a 4-event replay begin at fd7a):
+  rtl_433 -f 868.20M -Y minmax \
+    -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
 The flex "decode_mc" option is NOT usable here: it aborts at the first Manchester
 violation and only tries phase 0, so these phase-offset, slightly-noisy packets
 collapse to empty rows - which is exactly why this C decoder rolls its own pass.

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -61,7 +61,8 @@ Manchester-decoded payload as a hex string, so captures can be correlated with
 the display. It ships disabled until the fields and CRC are pinned down.
 
 Flex-decoder equivalent for a first capture pass (100 kbps, then Manchester by
-eye): rtl_433 -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100'
+eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike (see
+docs/rtl433.md): rtl_433 -f 868.20M -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100'
 */
 
 #include "decoder.h"
@@ -85,6 +86,13 @@ static inline int uclean1_bit(uint8_t const *buf, unsigned i)
 // Manchester-decode `nbits` raw bits from `raw` (packed) starting at raw-bit
 // `start`, convention raw 01->1, raw 10->0. Writes packed decoded bits to `out`.
 // Returns number of decoded bits; *illegal counts 00/11 violations.
+//
+// rtl_433 does ship bitbuffer_manchester_decode(), which uses this same
+// convention (it emits the second bit of each pair). We deliberately don't use
+// it here: it aborts at the FIRST Manchester violation and decodes a single
+// phase alignment. Real captures of this link carry ~3-4% illegal pairs (noise)
+// at an unknown bit phase, so we instead tolerate violations, count them as a
+// quality metric, and let the caller try both phases and keep the cleaner one.
 static unsigned uclean1_manchester(uint8_t const *raw, unsigned start,
         unsigned nbits, uint8_t *out, unsigned out_cap_bits, unsigned *illegal)
 {

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -159,7 +159,7 @@ static int uponor_clean1_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
         /* clang-format off */
         data_t *data = data_make(
-                "model",        "",             DATA_STRING, "Uponor-Clean1",
+                "model",        "",             DATA_STRING, "Uponor-Clean-1",
                 "header",       "Header",       DATA_STRING, header_str,
                 "payload",      "Payload",      DATA_STRING, payload_str,
                 "payload_len",  "Payload bytes",DATA_INT,    (int)payload_len,

--- a/tools/rtl433/uponor_clean1.c
+++ b/tools/rtl433/uponor_clean1.c
@@ -63,12 +63,18 @@ the display. It ships disabled until the fields and CRC are pinned down.
 Flex-decoder equivalent for a first capture pass (raw on-air bits, Manchester by
 eye). Tune ~150 kHz low so the carrier lands off the RTL-SDR DC spike; -Y minmax
 selects the FSK peak detector (otherwise weak packets fragment) and bits>=400
-drops the noise rows (real packets are ~650 raw bits). preamble is the SAME fd7a
-sync this decoder anchors on, expressed in the raw (Manchester-encoded) domain:
-decoded fd 7a = 11111101 01111010, encode 1->01/0->10 => raw 0x5559 0x9566. It
-aligns every packet to the same start (all 8 in a 4-event replay begin at fd7a):
-  rtl_433 -f 868.20M -Y minmax \
-    -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400,preamble={32}55599566'
+drops the noise rows (real packets are ~650 raw bits):
+  rtl_433 -f 868.20M -Y minmax -X 'n=uclean1,m=FSK_PCM,s=10,l=10,r=100,bits>=400'
+Optionally add ,preamble={32}55599566 to strip the leading 0xBA run and align
+every row to the fd7a header - that value is the SAME sync this decoder anchors
+on, in the raw (Manchester-encoded) domain: decoded fd 7a = 11111101 01111010,
+encode 1->01/0->10 => raw 0x5559 0x9566. But keep it OPTIONAL: the flex preamble
+is an EXACT match over all 32 raw bits, so a single noise-flipped bit in the sync
+drops the whole packet - which is why on a live capture it can miss the weaker
+(far-unit) packet of an exchange. This C decoder avoids that by Manchester-
+decoding with tolerance FIRST and only then bit-searching for fd7a, so a stray
+bit costs alignment, not the whole frame. Use bits>=400 (no preamble) when you
+want to see every message; add preamble only when you want tidy aligned rows.
 The flex "decode_mc" option is NOT usable here: it aborts at the first Manchester
 violation and only tries phase 0, so these phase-offset, slightly-noisy packets
 collapse to empty rows - which is exactly why this C decoder rolls its own pass.


### PR DESCRIPTION
## Summary
- Add the rtl_433 decoder for the Uponor Clean 1 868 MHz inner/outer link, built from real RTL-SDR captures: **100 kbps line rate** carrying **software-Manchester** data (raw `01`->1, `10`->0), ~40 bytes/packet, constant `fd7a bababa 83` header, near-static telemetry sent as a **two-packet exchange every ~62 s**. Demods at 100 kbps, Manchester-decodes both bit phases and keeps the cleaner one, anchors on `fd7a`, emits header + raw payload hex. Ships `disabled=1` until fields/CRC are pinned down.
- `docs/rtl433.md`: capture procedure, empirical results, and a firmware section. Ghidra analysis of the MC9S08 flash shows the **on-air byte layout is not in the CPU** — it is only an SPI *slave* on a custom MC9S08<->8051 message bus; the nRF9E5's 8051 owns framing/Manchester. Firmware does give the decode *targets* (alarm-code and setpoint tables), so field mapping (`[U6]`) needs a display-correlated capture.
- Add the Ghidra helper scripts used: `DumpBytes`, `FindRefsInRange`, `ForceDecompile`.
- `.gitignore` ignores `*.cu8` (large IQ captures stay local).

## Test plan
- [ ] Build inside an rtl_433 checkout (copy `tools/rtl433/uponor_clean1.c` into `src/devices/`, register in `include/rtl_433_devices.h` + `src/CMakeLists.txt`, `cmake && make`).
- [ ] Run against a capture with `-R <num>` (decoder is disabled by default) and confirm it emits the `fd7a bababa 83` header + payload hex.
- [ ] Field semantics (`[U6]`) still require a display-correlated capture before enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)