### PR TITLE
Point nRF9E5 datasheet at working (Wayback) PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Attempted to read the modem port directly with a laptop and a USB-to-serial cabl
 ## Datasheets 
 | No       | Description | IC           |
 | ---      | ---         |---           |
-| U1       | Transceiver | [nRF9E5](https://docs.nordicsemi.com/r/bundle/ps_nRF9E5/) |
+| U1       | Transceiver | [nRF9E5](https://web.archive.org/web/20240428224643/https://infocenter.nordicsemi.com/pdf/nRF9E5_PS_v1.6.pdf) |
 | U2       | CPU         | [MC9S08GT32ACFBE](https://www.nxp.com/docs/en/data-sheet/MC9S08GB60A.pdf)  |
 | U10      | Serial      | [sipex 3232](https://www.silicon-ark.co.uk/datasheets/sp3222_3232e-datasheet-sipex.pdf)   |
 | U3       | I2C Mem     | [4128BWP 8424K](https://www.st.com/en/memories/m24128-bw.html) |


### PR DESCRIPTION
## Summary
Follow-up to #61. The link merged there (`docs.nordicsemi.com/r/bundle/ps_nRF9E5/`) is still broken — Nordic's live docs site is behind a Cloudflare JS/cookie challenge and returns a "Just a moment..." page instead of the datasheet.

Repointed at the Internet Archive snapshot of the **v1.6 product spec PDF**, which serves `application/pdf` directly (26 pages, verified).

## Test plan
- [x] Landing page from #61: returns Cloudflare challenge, no PDF
- [x] New Wayback URL: `curl -L` returns `application/pdf`, valid 26-page PDF v1.6