### PR TITLE
Add frame-structure & checksum advances to rtl433.md

### DIFF
--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -180,6 +180,83 @@ by the known step). Change **one** thing at a time.
 
 ---
 
+## 0d. Advances: frame structure & checksum
+
+Two things unblocked a deeper look at the payload: a **standalone raw-IQ
+demodulator** (so we no longer depend on rtl_433's flex decoder to get bits), and
+a **1.5 h idle log** of 730 frames that exposed which bytes are constant vs.
+variable. Results below.
+
+### A working demod recipe (numpy, no rtl_433)
+
+Given one clean `.cu8` capture of a single poll+response exchange, this reproduces
+the exact rtl_433 frames with **zero illegal Manchester pairs**:
+
+1. Load the interleaved unsigned-8-bit IQ, recenter on 127.5, make it complex.
+2. FM-discriminate: `d = np.angle(iq[1:] * np.conj(iq[:-1]))`.
+3. Find the bursts (contiguous high-magnitude spans).
+4. Recover the chip clock by **fixed-rate resampling** at ~**10.0 samples/chip**
+   (1 MS/s ÷ ~100 kbps), scanning the start phase in ~0.5-sample steps and the
+   unit in 0.05-sample steps; hard-slice each chip on the sign of `d`.
+5. Manchester-decode the chips (`01 → 1`, `10 → 0`), scan both bit-parities, and
+   search for the header bits `fd 7a ba ba ba 83`.
+
+The winning parameters for `g001_868.2M_1000k.cu8` were `unit≈10.0`, and both
+bursts decoded with **0** illegal pairs, byte-for-byte matching the section-0c
+frames. This confirms the flex-decoder output is faithful and gives a tool that
+can attack **bit alignment** directly (see the checksum note below).
+
+### The poll payload is plaintext — a doubled 13-byte record
+
+The idle poll is not whitened or scrambled: it is literally the **same 13-byte
+record sent twice**, with flags and a trailer appended (33 payload bytes total
+after the header):
+
+    [73 1b 83 ff ff ff f0 03 e4 00 49 6d a5]  record (13 B, idle template)
+     83                                         separator
+    [73 1b 83 ff ff ff f0 03 e4 00 49 6d a5]  record repeat
+     bc                                         flag byte (bc ↔ ac, one bit)
+     95 1f                                      constant marker on every poll
+     f6                                         flag byte (f6 ↔ e6, one bit)
+     0c a2                                      2-byte trailer (content-dependent)
+
+Record layout (13 B): `73 1b`(magic) · `TT`(status: `83` idle / `93` active) ·
+4-byte field · 3-byte field · `49`(const) · 2-byte tail. During a treatment cycle
+**record A updates first while record B still holds the idle template** — so the
+frame carries **two records** (current + counterpart), consistent with the
+source/destination node-ID reading in section 0c.
+
+### The response frame is 100 % static
+
+Across the whole 1.5 h log, all **136** response frames were byte-identical; every
+bit of variation lived in the poll stream (30 distinct poll frames out of 594).
+So in normal idle only the poll side is worth diffing.
+
+### The 2-byte trailer is NOT a standard CRC `[U4]`
+
+Using a **differential** method — comparing frame-pair deltas, which cancels the
+constant header/marker bytes and is independent of the CRC `init`/`xorout` — the
+trailer (bytes 31–32) was tested against:
+
+- **CRC-16**: all **65536** polynomials × both byte-endiannesses × all
+  reflection settings (refin/refout) × forward **and** reversed message-byte
+  order, at both whole-frame and per-record scope → **0 matches**.
+- **CRC-8** on each trailer byte independently → 0 matches.
+- **sum8, sum16, xor8, Fletcher-16, Adler** → 0 matches.
+
+Yet two idle frames that differ by only **one bit** (byte 27 `bc↔ac`, or byte 30
+`f6↔e6`) still produce different trailers, so it **is** a content-dependent check
+— just a **nonlinear / proprietary** one, not a bit-serial CRC. The de-whitening /
+bit-alignment question is therefore closed: the frame is already plaintext, so the
+remaining blocker is the check *function*, which likely needs the nRF9E5's 8051
+image (Path C) or many labelled captures to pin down.
+
+**Practical upshot:** we do **not** need the trailer to read telemetry. The
+payload is plaintext, so fields can be mapped purely by correlating byte changes
+with device state (the `testknapp` / valve-cycle experiment in 0b/section 1).
+
+---
+
 ## 1. Capture raw IQ for analysis
 
 You need real captures before the decoder can be validated. Based on section 0,


### PR DESCRIPTION
## Summary
Adds a new **"0d. Advances: frame structure & checksum"** section to `docs/rtl433.md` capturing recent decoding progress:

- **Standalone numpy raw-IQ demod recipe** — FM-discriminate + fixed-rate resample (~10 samples/chip, phase/unit scan) + Manchester decode; reproduces the section-0c frames with **zero illegal Manchester pairs**, independent of rtl_433.
- **Poll payload is plaintext** — a doubled 13-byte record + flag bytes + constant `95 1f` marker + 2-byte trailer; record A updates first during a cycle while record B holds the idle template.
- **Response frame is 100% static** across the 1.5 h / 136-frame log.
- **2-byte trailer is not a standard CRC** — differential test rules out all 65536 CRC-16 polys (both endiannesses, all reflections, fwd/rev byte order, whole-frame + per-record), CRC-8, sum8/16, xor8, Fletcher-16, Adler. Single-bit body changes still move the trailer, so it is a nonlinear/proprietary check. Telemetry can still be mapped without it since the payload is plaintext.

## Test plan
- [x] Markdown renders; docs-only change, no code/build impact.