### PR TITLE
Document the seven output-driver channels as OC1–OC7 / OC8–OC14 ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,20 @@ Attempted to read the modem port directly with a laptop and a USB-to-serial cabl
 | U2       | CPU         | [MC9S08GT32ACFBE](https://www.nxp.com/docs/en/data-sheet/MC9S08GB60A.pdf)  |
 | U10      | Serial      | [sipex 3232](https://www.silicon-ark.co.uk/datasheets/sp3222_3232e-datasheet-sipex.pdf)   |
 | U3       | I2C Mem     | [4128BWP 8424K](https://www.st.com/en/memories/m24128-bw.html) |
-| OC13     | Optoisolator| MOC3063 1512 |
-| D11      | Mosfet      | VNE46 AC 4DLMG |
-| OC6      | Mosfet      | 1435 814 |
+| OC8–OC14 | Optoisolator| MOC3063 1512 |
+| D6–D12   | Mosfet      | VNE46 AC 4DLMG |
+| OC1–OC7  | Mosfet      | 1435 814 |
+
+The board carries a row of **seven identical output-driver channels** (the
+repeated stages that switch the magnetventiler MV1–MV5, the compressor and the
+pumps), so the designators fall into three matched series — one part per channel:
+* **D6–D12** are all the same VNE46 mosfet as D11.
+* **OC1–OC7** are all the same 1435 814 mosfet as OC6.
+* **OC8–OC14** are all the same MOC3063 optoisolator as OC13.
+
+The two OC series interleave across the row as two descending runs (…OC14, OC7,
+OC13, OC6, OC12, OC5… reading left to right), read off the high-resolution
+silkscreen in `docs/uclean1-pcb.png`.
 
 ## I2C Memory (U3, 128-Kbit / 16 KB)
 U3 is an M24128 EEPROM on the I2C bus at address `0x50`, read with a Raspberry Pi


### PR DESCRIPTION
## Summary
- The datasheet table listed only single designators (`OC13`, `D11`, `OC6`) for the repeated output-driver stages. Reading the high-resolution silkscreen in `docs/uclean1-pcb.png` shows the driver row is **seven identical channels**, so those rows now carry the full ranges.
- Optoisolators (MOC3063) run **OC8–OC14**, small mosfets (1435 814) run **OC1–OC7**, and the VNE46 mosfets run **D6–D12** — one part of each per channel.
- Added a note explaining the two OC series interleave across the board as two descending runs (…OC14, OC7, OC13, OC6, OC12, OC5… left→right).

## Why
Documents the true part groupings so anyone tracing the board knows every MV/compressor/pump driver stage shares the same three parts, rather than assuming only one instance of each exists.

## Reviewer notes
- Ranges were read directly off native-resolution (4032×3024) crops of `docs/uclean1-pcb.png`; the D6 mosfet and a 1435 814 mosfet sit at the right board edge (series minima), OC14/OC7 are the left-most (maxima).
- Docs-only change; no code, build, or CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)