### PR TITLE
Document U2 GSM/SMS serial controller (Path A) + fake-Telit bench tool

### DIFF
--- a/docs/u2-serial-protocol.md
+++ b/docs/u2-serial-protocol.md
@@ -1,0 +1,106 @@
+# U2 serial / GSM-SMS controller (Path A)
+
+The U2 CPU (Freescale MC9S08GT32) does **not** just drive the actuators — its
+flash contains a full **GSM/SMS remote-monitoring controller**. It talks to a
+Telit cellular modem over one of its two SCI ports and exposes a text command
+interface that reports the plant's status, including the **cycle counter**
+(*satsräknare*) shown on the display. That makes the serial/modem port the most
+promising route to Home Assistant telemetry — it carries the counter and alarm
+state in plain ASCII, no radio decoding required.
+
+Everything below is recovered from `dumps/u2-mc9s08gt-flash.s19`; the bench steps
+are not yet done.
+
+## Firmware evidence
+
+Three independent findings in the dump identify U2 as a Telit modem host:
+
+1. **Full Telit AT command set** (`strings` on the flash):
+   `ATE0`, `AT+CMEE=1`, `AT+CPIN?`, `AT+CREG?`, `AT+CMGF=`, `AT+CSCS=`,
+   `AT+CNMI=`, `AT+CPMS=`, `AT+CMGS=`, `AT+CMGR=`, `AT+CMGD=1,4`, `AT+IPR=`,
+   `AT+IFC=0,0`, `AT#SELINT=`, `AT#BND=`, `AT+WMBS=`.
+2. **GSM-specific reply parsing**: `+CPIN: READY`, `CME ERROR`, `CMS ERROR` —
+   the firmware consumes modem result codes, so it is the DTE, not a passive port.
+3. **SCI2 baud hard-coded to 9600**. At flash **`0xA40A`**:
+
+   ```
+   mov #$20,SCI2BDL      ; 4E 20 41  -> SBR = 0x0020 = 32
+   ```
+
+   Baud = f_bus / (16 × SBR) = f_bus / 512. A **4.9152 MHz** bus clock (a classic
+   UART crystal) gives exactly **9600** — matching the `AT+IPR=9600` set on the
+   modem. So **SCI2 is the modem UART at 9600 8N1**.
+
+SCI1's baud divisor is loaded from the H:X register at runtime (no literal in the
+dump), consistent with SCI1 being the **local RS-232 service port** for the
+`CODE …` command interface below.
+
+## The command / telemetry interface
+
+The firmware implements a text protocol (delivered over SMS and/or the local
+serial port). Recovered tokens:
+
+- **Commands**: `CODE`, `CODE CONF`, `CODE CONF ?`, `CODE RS`.
+- **Status fields** (what a query returns): `CYCLE COUNTER:`, `PLANT STATUS:S`,
+  `ALARM STATUS:`, `SW Ver:`, `Proc Ver:`, `ID:`.
+- **Config keys**: `CODE=`, `REPLY=`, `HEARTBEAT=`, `SMSCOUNTER=`,
+  `PHONE1=` / `PHONE2=` / `PHONE3=`.
+- **Alarm strings**: `No radio connection`, `Chemical level low`,
+  `High water …`, `Compressor fault`, `MV1`–`MV5 fault`, `EEPROM error`,
+  `Sludge empty remind`, `GSM fault`.
+
+The stored placeholders are non-secret defaults (`PASS`, `+358000000000`).
+
+`CYCLE COUNTER:` is exactly the display's *satsräknare* — reaching it over the
+serial port is the goal of Path A.
+
+## Hardware access
+
+The port is RS-232 via **U10 (SP3232)**, a 2-channel RS-232 transceiver. To reach
+SCI2 you tap the **TTL side** at the SP3232 (the connector side is ±RS-232 and
+will fry a 3.3 V UART):
+
+| SP3232 pin | signal | direction |
+| ---        | ---    | ---       |
+| 11 `T1IN`  | TTL in  | from a U2 TxD |
+| 10 `T2IN`  | TTL in  | from a U2 TxD |
+| 12 `R1OUT` | TTL out | to a U2 RxD |
+|  9 `R2OUT` | TTL out | to a U2 RxD |
+| 14 `T1OUT` / 7 `T2OUT` | RS-232 out | to the connector |
+| 13 `R1IN` / 8 `R2IN`   | RS-232 in  | from the connector |
+
+Which SP3232 channel is SCI2 is not yet traced — identify it empirically in
+tier 2 below (the one emitting 9600-baud `AT…` text at power-up).
+
+> The earlier Path-A attempt ("port appeared dead, swept common bauds") is
+> explained by this thesis: with no modem attached U2 mostly stays quiet, and a
+> TTL adapter on the RS-232 connector (or on U2's RxD, where only the *modem*
+> would talk) sees nothing. Listen on the **TxD/TTL** side instead.
+
+## Verification plan
+
+**Tier 1 — static (done).** The three firmware findings above.
+
+**Tier 2 — passive scope (decisive, ~5 min).** Logic analyzer / 3.3 V USB-UART on
+SP3232 `T1IN` (pin 11) and `T2IN` (pin 10), **9600 8N1**, then power-cycle the
+board. Prediction: a burst of printable ASCII — `ATE0`, `AT+CPIN?`,
+`AT+CREG?`… Seeing it on one pin confirms the thesis and identifies SCI2.
+
+**Tier 3 — fake modem, no SIM (strongest bench proof).** Cross-connect a 3.3 V
+USB-UART to that SCI2 pair (TX↔RX, common ground) and run
+[`tools/fake_telit.py`](../tools/fake_telit.py):
+
+```
+python3 tools/fake_telit.py --port /dev/ttyUSB0
+```
+
+It answers U2's init handshake so U2 believes a registered modem is present, then
+**captures the SMS body U2 sends** (`AT+CMGS`) — which contains `CYCLE COUNTER:`,
+`PLANT STATUS:` and `ALARM STATUS:`. Press Enter to inject a fake incoming
+`CODE STATUS` SMS and exercise the query→reply path (`+CMTI` → `AT+CMGR`).
+
+**Tier 4 — full GSM (end-to-end).** Real SIM + antenna; text the unit its
+`CODE …` query and read the reply.
+
+Recommended: **tier 2 → tier 3**. Tier 2 is a yes/no; tier 3 turns it into a
+working, SIM-free telemetry tap that already yields the cycle counter.

--- a/docs/u2-serial-protocol.md
+++ b/docs/u2-serial-protocol.md
@@ -57,17 +57,24 @@ serial port is the goal of Path A.
 ## Hardware access — J5 "Modem" header
 
 The board has a header **J5**, silk-labeled **"Modem"**, sitting next to U10
-(SP3232) and U13. It is a **5 V TTL** modem-module header (multimeter mapped,
-diode/continuity + powered voltage check), *not* an RS-232 port — so a plain
-USB-UART reaches it directly, no MAX3232 needed. Pinout (top → bottom):
+(SP3232) and U13. It is a **2×5 (10-pin)** right-angle header at **5 V TTL**
+(multimeter mapped, diode/continuity + powered voltage check), *not* an RS-232
+port — so a plain USB-UART reaches it directly, no MAX3232 needed.
 
-| J5 pin | label | notes |
-| ---    | ---   | ---   |
-| 1 | **5V**  | power **output** (reads ~5.0 V to GND with board powered); feeds the modem module — **do not** drive it from a USB-UART |
-| 2 | *(unlabeled)* | 5th pin, function TBD (2nd GND / RING / power-key?) |
-| 3 | **RX**  | serial |
-| 4 | **TX**  | serial |
-| 5 | **GND** | ground |
+Four signals are mapped so far (on the edge row):
+
+| signal | notes |
+| ---    | ---   |
+| **5V**  | power **output** (reads ~5.0 V to GND with board powered); feeds the modem module — **do not** drive it from a USB-UART |
+| **RX**  | serial |
+| **TX**  | serial |
+| **GND** | ground |
+
+The remaining six pins are not yet mapped. A 2×5 modem interface most likely
+carries the hardware-handshake lines (RTS/CTS/DTR/DSR/DCD/RI) — though the
+firmware disables flow control (`AT+IFC=0,0`), so only power + RX/TX/GND are
+needed to talk to it. RING (RI) is a plausible incoming-SMS wake line worth
+identifying.
 
 The board logic is **5 V** (the 5V pin reads ~5.0 V; a UART line idles high at the
 logic rail). RX/TX are labeled by hand and their perspective (host vs. module) is
@@ -95,16 +102,16 @@ firmware's `CODE RS` command — i.e. **SCI2 → J5 (TTL) → modem**, while
 
 **Tier 1 — static (done).** The three firmware findings above.
 
-**Tier 2 — passive scope (decisive, ~5 min).** Logic analyzer / USB-UART on
-**J5 pins 3 and 4** (RX/TX), **9600 8N1**, GND to J5 pin 5, then power-cycle the
+**Tier 2 — passive scope (decisive, ~5 min).** Logic analyzer / USB-UART on the
+**J5 RX/TX pins**, **9600 8N1**, GND to the J5 GND pin, then power-cycle the
 board. Prediction: a burst of printable ASCII — `ATE0`, `AT+CPIN?`,
 `AT+CREG?`… The pin that bursts is U2's transmit (that also resolves the RX/TX
 labels).
 
 **Tier 3 — fake modem, no SIM (strongest bench proof).** Cross-connect a USB-UART
 to J5 (adapter **RX ← J5 TX** = the bursting pin, adapter **TX → J5 RX**, GND to
-J5 pin 5, **5V pin left unconnected**; mind the 5 V level cautions above) and run
-[`tools/fake_telit.py`](../tools/fake_telit.py):
+the J5 GND pin, **5V pin left unconnected**; mind the 5 V level cautions above)
+and run [`tools/fake_telit.py`](../tools/fake_telit.py):
 
 ```
 python3 tools/fake_telit.py --port /dev/ttyUSB0

--- a/docs/u2-serial-protocol.md
+++ b/docs/u2-serial-protocol.md
@@ -54,40 +54,56 @@ The stored placeholders are non-secret defaults (`PASS`, `+358000000000`).
 `CYCLE COUNTER:` is exactly the display's *satsräknare* — reaching it over the
 serial port is the goal of Path A.
 
-## Hardware access
+## Hardware access — J5 "Modem" header
 
-The port is RS-232 via **U10 (SP3232)**, a 2-channel RS-232 transceiver. To reach
-SCI2 you tap the **TTL side** at the SP3232 (the connector side is ±RS-232 and
-will fry a 3.3 V UART):
+The board has a header **J5**, silk-labeled **"Modem"**, sitting next to U10
+(SP3232) and U13. It is a **5 V TTL** modem-module header (multimeter mapped,
+diode/continuity + powered voltage check), *not* an RS-232 port — so a plain
+USB-UART reaches it directly, no MAX3232 needed. Pinout (top → bottom):
 
-| SP3232 pin | signal | direction |
-| ---        | ---    | ---       |
-| 11 `T1IN`  | TTL in  | from a U2 TxD |
-| 10 `T2IN`  | TTL in  | from a U2 TxD |
-| 12 `R1OUT` | TTL out | to a U2 RxD |
-|  9 `R2OUT` | TTL out | to a U2 RxD |
-| 14 `T1OUT` / 7 `T2OUT` | RS-232 out | to the connector |
-| 13 `R1IN` / 8 `R2IN`   | RS-232 in  | from the connector |
+| J5 pin | label | notes |
+| ---    | ---   | ---   |
+| 1 | **5V**  | power **output** (reads ~5.0 V to GND with board powered); feeds the modem module — **do not** drive it from a USB-UART |
+| 2 | *(unlabeled)* | 5th pin, function TBD (2nd GND / RING / power-key?) |
+| 3 | **RX**  | serial |
+| 4 | **TX**  | serial |
+| 5 | **GND** | ground |
 
-Which SP3232 channel is SCI2 is not yet traced — identify it empirically in
-tier 2 below (the one emitting 9600-baud `AT…` text at power-up).
+The board logic is **5 V** (the 5V pin reads ~5.0 V; a UART line idles high at the
+logic rail). RX/TX are labeled by hand and their perspective (host vs. module) is
+not yet pinned down — tier 2 below resolves it: the pin that *bursts* `AT…` at
+power-up is U2's transmit.
+
+This also places U10/SP3232 on a **separate** RS-232 service port, matching the
+firmware's `CODE RS` command — i.e. **SCI2 → J5 (TTL) → modem**, while
+**SCI1 → SP3232 → RS-232 service connector** carries the local `CODE …` interface.
 
 > The earlier Path-A attempt ("port appeared dead, swept common bauds") is
-> explained by this thesis: with no modem attached U2 mostly stays quiet, and a
-> TTL adapter on the RS-232 connector (or on U2's RxD, where only the *modem*
-> would talk) sees nothing. Listen on the **TxD/TTL** side instead.
+> explained by this: with no modem attached U2 mostly stays quiet, and probing
+> the wrong pin/direction (or the SP3232 RS-232 service port) sees nothing. Listen
+> on **J5 TX** at power-up instead.
+
+### Level / wiring cautions (5 V TTL)
+- **Never connect a USB-UART's VCC to J5 pin 1.** It is a board output; only wire
+  **GND + the two data lines**.
+- If your adapter is 3.3 V: its 3.3 V TX into a 5 V input reads as a valid high,
+  but protect its RX against the 5 V TX (series resistor / divider). A 5 V-capable
+  adapter avoids the issue.
+- Common ground between adapter and board.
 
 ## Verification plan
 
 **Tier 1 — static (done).** The three firmware findings above.
 
-**Tier 2 — passive scope (decisive, ~5 min).** Logic analyzer / 3.3 V USB-UART on
-SP3232 `T1IN` (pin 11) and `T2IN` (pin 10), **9600 8N1**, then power-cycle the
+**Tier 2 — passive scope (decisive, ~5 min).** Logic analyzer / USB-UART on
+**J5 pins 3 and 4** (RX/TX), **9600 8N1**, GND to J5 pin 5, then power-cycle the
 board. Prediction: a burst of printable ASCII — `ATE0`, `AT+CPIN?`,
-`AT+CREG?`… Seeing it on one pin confirms the thesis and identifies SCI2.
+`AT+CREG?`… The pin that bursts is U2's transmit (that also resolves the RX/TX
+labels).
 
-**Tier 3 — fake modem, no SIM (strongest bench proof).** Cross-connect a 3.3 V
-USB-UART to that SCI2 pair (TX↔RX, common ground) and run
+**Tier 3 — fake modem, no SIM (strongest bench proof).** Cross-connect a USB-UART
+to J5 (adapter **RX ← J5 TX** = the bursting pin, adapter **TX → J5 RX**, GND to
+J5 pin 5, **5V pin left unconnected**; mind the 5 V level cautions above) and run
 [`tools/fake_telit.py`](../tools/fake_telit.py):
 
 ```

--- a/tools/fake_telit.py
+++ b/tools/fake_telit.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Fake Telit GSM modem for bench-testing the Uponor Clean 1 U2 (MC9S08GT).
+
+Thesis under test: U2 runs a GSM/SMS controller that drives a Telit modem over
+SCI2 at 9600 8N1 (baud divisor SBR=32 found at flash 0xA40A -> 9600 @ 4.9152 MHz
+bus). This script impersonates the modem so U2 completes its init handshake with
+no SIM/network, and — the payoff — captures the status SMS U2 tries to SEND
+(AT+CMGS), whose body contains CYCLE COUNTER / PLANT STATUS / ALARM STATUS.
+
+Wiring: connect a 3.3 V USB-UART to the SCI2 lines (the SP3232 channel that emits
+9600-baud AT text at power-up). Cross TX<->RX. Match logic levels: tap the TTL
+side at SP3232 (T?IN / R?OUT), NOT the RS-232 connector, unless your adapter is
+RS-232. Common ground.
+
+Usage:
+    python3 fake_telit.py --port /dev/ttyUSB0
+    python3 fake_telit.py --port /dev/ttyUSB0 --inject "CODE STATUS"   # push a
+        fake incoming command SMS so U2 issues AT+CMGR and then replies.
+
+Press Enter at the console at any time to inject the --inject text as a new SMS.
+"""
+import argparse
+import sys
+import threading
+import time
+
+try:
+    import serial
+except ImportError:
+    sys.exit("pyserial not installed:  pip install pyserial")
+
+CRLF = b"\r\n"
+
+
+def ts():
+    return time.strftime("%H:%M:%S")
+
+
+class FakeTelit:
+    def __init__(self, ser, inject_text):
+        self.ser = ser
+        self.inject_text = inject_text
+        self.have_injected_msg = False  # a pending "stored" incoming SMS at index 1
+
+    def send(self, text):
+        """Send a Telit-style response line (framed with CRLF like a real modem)."""
+        data = CRLF + text.encode() + CRLF if text else CRLF
+        self.ser.write(data)
+        print(f"[{ts()}] TX-> {text!r}")
+
+    def ok(self):
+        self.send("OK")
+
+    def handle(self, cmd):
+        print(f"[{ts()}] <-RX {cmd!r}")
+        c = cmd.strip().upper()
+
+        # --- SMS SEND: capture the telemetry body ---------------------------
+        if c.startswith("AT+CMGS"):
+            # Text mode: modem prompts with "> ", host sends body + Ctrl-Z(0x1A).
+            self.ser.write(b"\r\n> ")
+            print(f"[{ts()}] TX-> '> '  (waiting for SMS body + Ctrl-Z)")
+            body = self.read_until_ctrlz()
+            print("=" * 60)
+            print(f"[{ts()}] *** CAPTURED OUTGOING SMS BODY (telemetry) ***")
+            print(body.decode(errors="replace"))
+            print("=" * 60)
+            self.send("+CMGS: 1")
+            self.ok()
+            return
+
+        # --- SMS READ: hand U2 the injected incoming command ----------------
+        if c.startswith("AT+CMGR"):
+            if self.have_injected_msg:
+                # +CMGR: <stat>,<oa>,,<scts>  then the text  then OK
+                self.send('+CMGR: "REC UNREAD","+358000000000",,"'
+                          '00/01/01,00:00:00+00"')
+                self.ser.write(self.inject_text.encode() + CRLF)
+                print(f"[{ts()}] TX-> injected SMS text {self.inject_text!r}")
+                self.have_injected_msg = False
+                self.ok()
+            else:
+                self.send("+CMS ERROR: 321")  # invalid memory index
+            return
+
+        # --- SIM / registration / config: report happy, registered ----------
+        if c.startswith("AT+CPIN"):
+            self.send("+CPIN: READY"); self.ok(); return
+        if c.startswith("AT+CREG"):
+            self.send("+CREG: 0,1"); self.ok(); return   # registered, home
+        if c.startswith("AT+CSQ"):
+            self.send("+CSQ: 20,0"); self.ok(); return
+        if c.startswith("AT+CPMS"):
+            self.send("+CPMS: 1,50,1,50,1,50"); self.ok(); return
+        if c.startswith("AT+CMGL"):
+            # list messages: pretend none unless one injected
+            if self.have_injected_msg:
+                self.send('+CMGL: 1,"REC UNREAD","+358000000000",,')
+                self.ser.write(self.inject_text.encode() + CRLF)
+                self.have_injected_msg = False
+            self.ok(); return
+
+        # --- everything else (ATE0, CMEE, CMGF, CNMI, CSCS, IPR, IFC,
+        #     #SELINT, #BND, WMBS, CMGD, plain AT ...): just acknowledge ------
+        if c.startswith("AT"):
+            self.ok(); return
+
+        # non-AT noise
+        print(f"[{ts()}] (ignored non-AT input {cmd!r})")
+
+    def read_until_ctrlz(self, timeout=5.0):
+        buf = bytearray()
+        end = time.time() + timeout
+        while time.time() < end:
+            b = self.ser.read(1)
+            if not b:
+                continue
+            if b[0] == 0x1A:      # Ctrl-Z = send
+                break
+            if b[0] == 0x1B:      # ESC = abort
+                break
+            buf += b
+        return bytes(buf)
+
+    def reader_loop(self):
+        line = bytearray()
+        while True:
+            b = self.ser.read(1)
+            if not b:
+                continue
+            if b[0] in (0x0D, 0x0A):   # CR or LF ends a command
+                if line:
+                    self.handle(bytes(line).decode(errors="replace"))
+                    line = bytearray()
+            else:
+                line += b
+
+    def console_loop(self):
+        for _ in sys.stdin:
+            self.have_injected_msg = True
+            # Nudge U2 to read it: unsolicited new-message indication.
+            self.send('+CMTI: "SM",1')
+            print(f"[{ts()}] queued injected SMS {self.inject_text!r}; sent +CMTI")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", required=True, help="e.g. /dev/ttyUSB0")
+    ap.add_argument("--baud", type=int, default=9600)
+    ap.add_argument("--inject", default="CODE STATUS",
+                    help="text delivered as an incoming SMS when you press Enter")
+    args = ap.parse_args()
+
+    ser = serial.Serial(args.port, args.baud, bytesize=8, parity="N",
+                        stopbits=1, timeout=0.2)
+    print(f"[{ts()}] fake Telit on {args.port} @ {args.baud} 8N1")
+    print("Press Enter to inject an incoming command SMS. Ctrl-C to quit.")
+    ft = FakeTelit(ser, args.inject)
+    threading.Thread(target=ft.reader_loop, daemon=True).start()
+    try:
+        ft.console_loop()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `docs/u2-serial-protocol.md` documenting **Path A**: the U2 CPU runs a **Telit GSM/SMS remote-monitoring controller**, not just an actuator driver. It talks to a cellular modem on **SCI2 at 9600 8N1** and exposes a `CODE …` text interface that reports `CYCLE COUNTER:` (the display's *satsräknare*), `PLANT STATUS:` and `ALARM STATUS:`.
- Adds `tools/fake_telit.py`, a pyserial script that impersonates the modem so U2 completes its init handshake **with no SIM/network**, and captures the status SMS body U2 tries to send (`AT+CMGS`) — extracting the cycle counter at the bench.

## Firmware evidence (from `dumps/u2-mc9s08gt-flash.s19`)
1. Full Telit AT set (`ATE0`, `AT+CPIN?`, `AT+CREG?`, `AT+CMGF=`, `AT+CMGS=`, `AT+CMGR=`, `AT#SELINT=`, `AT#BND=`, …).
2. GSM result-code parsing (`+CPIN: READY`, `CME ERROR`, `CMS ERROR`) — U2 is the DTE.
3. SCI2 baud hard-coded: `0xA40A: mov #$20,SCI2BDL` → SBR=32 → 9600 @ 4.9152 MHz bus, matching `AT+IPR=9600`.

## Why
Path A carries the telemetry we want (cycle counter + alarms) in plain ASCII, so it's likely an easier route into Home Assistant than decoding the 868 MHz radio. This records the evidence and a concrete, tiered bench-verification plan so the port can be confirmed without guesswork.

## Reviewer notes
- Docs + a standalone bench script; no build/CI impact. The script is inert without hardware.
- The earlier "modem port appeared dead" observation is explained in the doc (wrong pin/level/direction, and U2 stays quiet with no modem attached).
- Bench work (tiers 2–4) is not yet done; nothing here asserts a completed hardware test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)