### PR TITLE
Document A/B board provenance; fix EEPROM config offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ Investigate if its possible to get Uponor Clean 1 into Home Assistant
 
 ![PCB with text](docs/uclean1-pcb.png)
 
+## Two boards (dump vs. radio provenance)
+This project uses **two physical Clean 1 boards**, and it matters which artifact
+came from which:
+* **Board A** — the original, retired after **OC13** (a MOC3063 output-driver
+  optotriac, one of the OC8–OC14 channels) failed. **All firmware and memory
+  dumps in [`dumps/`](dumps/) were read from board A** (`u2-mc9s08gt-flash.*`,
+  `u3-m24128-eeprom.bin`). OC13 is only an output stage, so its CPU / serial /
+  EEPROM / radio are intact — board A is the safe **bench mule**.
+* **Board B** — the new **active replacement**, currently installed. **All
+  868 MHz `rtl_433` radio captures come from board B**, as does the display's
+  cycle counter (*satsräknare*).
+
+So firmware/EEPROM analysis describes **board A** and on-air behaviour describes
+**board B**. They are the same model but not guaranteed byte-identical — the
+EEPROM config (code + phone numbers) and the counter differ per board, and the
+radios may be individually paired. Confirm `SW Ver:` / `Proc Ver:` match on both
+before using board-A firmware to explain board-B radio.
+
 ## Modem port / serial (Path A)
 Attempted to read the modem port directly with a laptop and a USB-to-serial cable, sweeping the common baud rates. No traffic was observed on any of them — the port appeared dead. This avenue is parked for now in favour of the flash/firmware work below (Path B).
 

--- a/docs/eeprom-map.md
+++ b/docs/eeprom-map.md
@@ -3,6 +3,11 @@
 Derived from a full 16 KB dump ([`dumps/u3-m24128-eeprom.bin`](../dumps/u3-m24128-eeprom.bin),
 16384 bytes) — see [docs/u3-eeprom.md](u3-eeprom.md) for how it was read.
 
+> **Provenance:** this dump is from **board A** (the retired original, OC13
+> output-driver fault), not the live unit — see the two-boards note in the
+> [README](../README.md). So the config below (`PASS`, phone slots) is board A's,
+> and the display counter on the live board B is **not** in this dump.
+
 ## Summary
 
 Only two regions of the 16 KB are populated; everything else is erased
@@ -11,7 +16,7 @@ Only two regions of the 16 KB are populated; everything else is erased
 | Range           | Contents                                            |
 | ---             | ---                                                 |
 | `0x0000–0x05BF` | Static program table: header params, cycle/phase definitions + labels, alarm text, actuator-event timings |
-| `0x3A94–0x3AD6` | Live config: menu password + 3 GSM/SMS phone slots + trailing bytes |
+| `0x3A98–0x3AD6` | Live config: menu password + 3 GSM/SMS phone slots + trailing bytes |
 
 **Important for Home Assistant:** there is **no live telemetry** (water level,
 temperature, current phase, timers) stored in the EEPROM. Those are transient
@@ -20,13 +25,13 @@ and live in CPU RAM / are carried over the 868 MHz radio. The EEPROM holds the
 for **decoding/labelling** what the radio carries (phase names, alarm codes),
 not as a data source on its own.
 
-## `0x3A94–0x3AD6` — live config (GSM/SMS alerting)
+## `0x3A98–0x3AD6` — live config (GSM/SMS alerting)
 
 This region matches the firmware's typed read wrappers exactly (see the Ghidra
 analysis: `FUN_a554` + 5-byte / 16-byte / 2-byte wrappers).
 
 ```
-3a94: 00 00 00 08 01                                  header/flags
+3a98: 00 00 00 08 01                                  header/flags
 3a9d: 50 41 53 53 00                "PASS\0"           menu password (5-byte record)
 3aa2: 01 00 00                                         flags/count
 3aa5: 2b 33 35 38 30 30 30 30 30 30 30 30 30  "+358000000000"  phone slot 0  (16-byte stride)
@@ -38,9 +43,10 @@ analysis: `FUN_a554` + 5-byte / 16-byte / 2-byte wrappers).
 - **Password** `PASS` and all three **phone numbers** (`+358…`, Finland) are
   factory **placeholders / unconfigured** — no real credentials in this dump.
 - The unit sends **SMS alerts** to these numbers (the alarm strings below are
-  the message texts). This confirms the "modem port" is a GSM modem, and
-  explains why the serial tap (Path A) was silent — alerting is over the
-  cellular link, not that port.
+  the message texts). This confirms the "modem port" is a GSM link. The port
+  itself is the **J5 "Modem" header** (5 V TTL, on U2's SCI2 at 9600) — the
+  reason the first serial tap looked dead, and how to talk to it, are in
+  [docs/u2-serial-protocol.md](u2-serial-protocol.md).
 
 ## `0x0000–0x05BF` — static program table
 

--- a/docs/u3-eeprom.md
+++ b/docs/u3-eeprom.md
@@ -6,6 +6,10 @@ I2C bus at address **`0x50`** and holds the firmware's config + telemetry
 records. This page covers how to wire it to a Raspberry Pi, how to read it, and
 what we have found so far.
 
+> This dump is from **board A** (the retired original) — see the two-boards note
+> in the [README](../README.md). Board B (the live unit) will hold different
+> config.
+
 ## Wiring the Raspberry Pi to U3
 
 The M24128 is an 8-pin device (SO8/DIP8). Standard pinout:


### PR DESCRIPTION
## Summary
- Records that the project uses **two boards**: **board A** (retired original, failed on OC13 — an output-driver optotriac) is the source of **all firmware/EEPROM dumps**; **board B** (the live replacement) is the source of **all 868 MHz radio captures** and the displayed cycle counter. Adds a "Two boards" section to the README and provenance banners to `docs/eeprom-map.md` and `docs/u3-eeprom.md`.
- Fixes the U3 config-block start address from `0x3A94` to **`0x3A98`** (`0x3A94–0x3A97` are `0xFF`), in both the summary table and the hex listing.
- Reconciles a stale line in `eeprom-map.md`: the "modem port" is the **J5 'Modem' header** (5 V TTL on SCI2), now cross-linked to `docs/u2-serial-protocol.md`.

## Why
The dumps and the radio traffic come from **different physical units**, which changes how every artifact should be read (e.g. the live counter can't be in board A's EEPROM, and firmware↔radio comparisons assume the boards match). Capturing this avoids future misreadings. Board A being only an output-stage failure also means it's a safe bench mule for the Path A serial work.

## Reviewer notes
- Docs-only; no code/CI impact. The offset fix is verified against `dumps/u3-m24128-eeprom.bin` (`0x3A98: 00 00 00 08 01`, `PASS` at `0x3A9D`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)