### PR TITLE
Document counter absent from radio heartbeat (batch 1257->1258)

### DIFF
--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -257,6 +257,50 @@ with device state (the `testknapp` / valve-cycle experiment in 0b/section 1).
 
 ---
 
+## 0e. First display-correlated event: a full batch, counter 1257 → 1258
+
+A **~20 h continuous decode log** (`uclean1-20260702-2128.json`, 2597 frames,
+2026-07-02 21:29 → 2026-07-03 17:35, board B) was taken across a real change of
+the display's *satsräknare* (batch counter): it read **1257** at the start and
+**1258** at the end. This is the first capture that brackets a confirmed counter
+tick, so it directly answers whether the counter is on the radio.
+
+**The counter value is NOT in the radio payload.** The two heartbeat frames are
+**byte-identical across the entire span**, including before and after the tick:
+
+| frame    | occurrences | payload (33 B) |
+| ---      | ---         | --- |
+| poll     | 1029 identical | `731b93e0035bb008d2c0492e71b02f4ffcbd2e2aff97aff65ffffde9bfdafbbb42` |
+| response |  990 identical | `331ba3f008d2e0035b801c1171f51d2cffef7f3bbcf7de9fadb5fbabcfa2ffccd3` |
+
+If the satsräknare were encoded in the heartbeat, these bytes would differ
+before vs. after 1257 → 1258. They do not — so the number is not broadcast. That
+matches section 0b: the counter lives in the MC9S08 (U2) and is only reachable
+over the serial `CODE` interface, not the nRF905 link.
+
+**What the tick *does* look like on-air:** every byte of variation in the whole
+log is confined to a single **~55-minute burst, 23:03 → 23:58 on 2026-07-02** —
+the "active record" poll family from section 0d (status byte `83`→`93`, changing
+tails):
+
+    731b83fffffff003e400496da583 731b83fffffff003e400496da5 <tail>   (283× + 67× + 51× + 49× + …)
+    731b93e0035bb003e400491537…  (active variants, 25× + 10× + …)
+
+That burst is the **treatment batch running**; when it completed, the display
+went 1257 → 1258. Before and after it, the radio drops back to the two static
+heartbeats. So this is the section-0d prediction observed end-to-end: during a
+cycle **record A goes active while record B holds the idle template**, and the
+cycle's completion is what advances the counter.
+
+**Consequence for Home Assistant:** the radio reveals batch *events* (a burst =
+a cycle in progress → a `binary_sensor` for "treating"), but **not the counter
+value**. To surface the numeric satsräknare you still need the serial `CODE`
+path (Path A / [J5](u2-serial-protocol.md)). The `[U6]` field-mapping goal is
+unchanged; this capture just rules the counter out of the heartbeat and gives a
+timestamped batch window (23:03–23:58) to diff the active records against idle.
+
+---
+
 ## 1. Capture raw IQ for analysis
 
 You need real captures before the decoder can be validated. Based on section 0,


### PR DESCRIPTION
## Summary
Adds section **0e** to `docs/rtl433.md` from the first display-correlated capture that spans a real *satsräknare* tick.

- A ~20 h decode log (`uclean1-20260702-2128.json`, 2597 frames, 2026-07-02 21:29 → 07-03 17:35, board B) brackets the display counter changing **1257 → 1258**.
- **Both heartbeat frames are byte-identical across the whole span** (poll 1029×, response 990×), so the counter value is **not** broadcast on the nRF905 link — consistent with section 0b (counter lives in U2, serial `CODE` path only).
- The tick is visible on-air only as a single **~55-minute active-record burst (23:03–23:58 Jul-2)** = the treatment batch, confirming section 0d's two-record (active/idle) model end-to-end.
- **HA consequence:** radio yields a "treating" binary sensor; the numeric counter still needs Path A / J5 serial.

## Test plan
- [ ] Doc-only change; no code. Prose reviewed for consistency with sections 0c/0d/0b.
- [ ] Future: diff the 23:03–23:58 active records against the idle template to start `[U6]` field mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)