### PR TITLE
Path A validated on hardware: live telemetry over serial

### DIFF
--- a/docs/eeprom-map.md
+++ b/docs/eeprom-map.md
@@ -73,24 +73,29 @@ a phase-index byte, then a label of the form `"<cycle#> <PhaseName>"`.
 ### `0x03D4–0x04CF` — alarm / status message table
 
 Each entry is a **1-byte message code** followed by the display text. These are
-the states/faults the unit reports (and SMS-sends). Recovered codes:
+the states/faults the unit reports (and SMS-sends). The **Display** column is the
+`E`-code the styrskåp shows for the same fault, from the Uponor Clean I manual
+("Åtgärder vid störningar") — so byte / SMS text / display code are three views of
+one fault (see [u2-serial-protocol.md](u2-serial-protocol.md), `ALARM STATUS`):
 
-| Code | Text                |
-| ---  | ---                 |
-| 0x02 | No radio connection |
-| 0x15 | Chemical level low  |
-| 0x1F | High water; tank    |
-| 0x20 | High water; outlet  |
-| 0x28 | Compressor fault    |
-| 0x29 | MV1 fault           |
-| 0x2A | MV2 fault           |
-| 0x2B | MV3 fault           |
-| 0x2C | MV4 fault           |
-| 0x2D | MV5 fault           |
-| 0x2F | EEPROM error        |
-| 0x33 | Sludge empty remind |
+| Code | Text                | Display | Valve / cause |
+| ---  | ---                 | ---     | --- |
+| 0x02 | No radio connection | `E011`  | control-panel link lost |
+| 0x15 | Chemical level low  | `E021`  | low flocculant |
+| 0x1F | High water; tank    | `E031`  | inlet module blocked |
+| 0x20 | High water; outlet  | `E032`  | outlet / pump-out blocked |
+| 0x28 | Compressor fault    | `E040`  | air pump |
+| 0x29 | MV1 fault           | `E041`  | chemical-dosing valve |
+| 0x2A | MV2 fault           | `E042`  | sludge-return valve |
+| 0x2B | MV3 fault           | `E043`  | pump-out valve |
+| 0x2C | MV4 fault           | `E044`  | pump-in valve |
+| 0x2D | MV5 fault           | `E045`  | aeration valve |
+| 0x2F | EEPROM error        | `E034`/`E047` | control-cabinet / program fault (pairing unconfirmed) |
+| 0x33 | Sludge empty remind | `E051`  | septic section filling |
 
-(`MV1–MV5` = the five motor valves / solenoids; the phase list drives them.)
+So `MV1–MV5` are the five solenoid valves — **dosing, sludge-return, pump-out,
+pump-in, aeration** — which the phase list drives. (`E401`–`E403` are the 1/3/6-year
+service reminders; `E000` = no fault.)
 
 ### `0x04D0–0x05BF` — actuator event / timing table
 

--- a/docs/u2-serial-protocol.md
+++ b/docs/u2-serial-protocol.md
@@ -102,9 +102,8 @@ Notes:
   must poll it.
 - **`CYCLE COUNTER:2129` is board A's own counter**, not board B's display
   *satsräknare* (1258); the two boards keep independent counts.
-- **`PLANT STATUS:S102`** is a status code, not yet mapped. Decode it like the
-  radio `[U6]`: read `PASS` at known display phases and tabulate the `S<nnn>`
-  values against the EEPROM cycle/phase table.
+- **`PLANT STATUS:S102` = Aeration.** The `S`-codes are the treatment-cycle
+  step, decoded from the Uponor Clean 1 manual (full table below).
 - `ALARM STATUS` returns `NO` when clear; on a fault it carries the alarm text
   (`Compressor fault`, `MV1`-`MV5 fault`, `EEPROM error`, …).
 
@@ -113,6 +112,54 @@ an HA integration is a persistent fake-modem daemon that injects `PASS` on a
 timer, parses the three status lines, and publishes them to MQTT (`cycle_counter`,
 `plant_status`, `alarm_status`). No SIM, no cellular, no radio decode — the most
 direct telemetry route found.
+
+### `PLANT STATUS` `S<nnn>` codes (decoded from the manual)
+
+The `S`-codes are the treatment-cycle step shown on the styrskåp display. The
+hundreds digit is the cycle (1 = cleaning, 2 = waiting, 3 = maintenance,
+4 = test), matching the firmware's cycle-prefixed phase table:
+
+| Code(s)       | Meaning |
+| ---           | --- |
+| `S101`        | Filling the process tank |
+| `S102`        | **Aeration** (the captured value) |
+| `S103`–`S105` | Chemical dosing & mixing |
+| `S106`–`S108` | Excess-sludge return + post-sedimentation (`S108` = 2nd sedimentation) |
+| `S109`        | Discharge of cleaned water |
+| `S201`–`S204` | Waiting mode (vänteläge) |
+| `S301`–`S305` | Maintenance phase (underhållsfas) |
+| `S400`        | Test cycle started |
+| `S401`–`S408` | Test steps: pump-in, sludge-removal, pump-out, chem-fill, dose, settle, aeration I, aeration II |
+
+### `ALARM STATUS` / fault `E`-codes (three views of one fault)
+
+`ALARM STATUS` is `NO` when clear; a fault carries the alarm text, which the
+manual also shows as a display `E`-code. These line up with the EEPROM alarm
+table ([eeprom-map.md](eeprom-map.md)) — the SMS text, the display code, and the
+firmware byte are the same fault:
+
+| Display | SMS alarm text (EEPROM code) | Cause |
+| ---     | ---                          | --- |
+| `E011`  | No radio connection (`0x02`) | control-panel link lost |
+| `E021`  | Chemical level low (`0x15`)  | low flocculant |
+| `E031`  | High water; tank (`0x1F`)    | inlet module blocked |
+| `E032`  | High water; outlet (`0x20`)  | outlet / pump-out blocked |
+| `E040`  | Compressor fault (`0x28`)    | air-pump fault |
+| `E041`  | MV1 fault (`0x29`)           | chemical-dosing valve |
+| `E042`  | MV2 fault (`0x2A`)           | sludge-return valve |
+| `E043`  | MV3 fault (`0x2B`)           | pump-out valve |
+| `E044`  | MV4 fault (`0x2C`)           | pump-in valve |
+| `E045`  | MV5 fault (`0x2D`)           | aeration valve |
+| `E034`/`E047` | EEPROM error (`0x2F`)  | control-cabinet / program fault (exact pairing unconfirmed) |
+| `E051`  | Sludge empty remind (`0x33`) | septic section filling |
+| `E401`–`E403` | (service reminders)    | 1 / 3 / 6-year service due |
+| `E000`  | — (normal / after reset)     | no fault |
+
+So `MV1`–`MV5` are the five solenoid valves: dosing, sludge-return, pump-out,
+pump-in, aeration.
+
+Source: Uponor Clean I installation & operation manual (03/2026) — "Reningsverkets
+status" (S-codes) and "Åtgärder vid störningar" (E-codes).
 
 ## Hardware access — J5 "Modem" header
 

--- a/docs/u2-serial-protocol.md
+++ b/docs/u2-serial-protocol.md
@@ -8,8 +8,10 @@ interface that reports the plant's status, including the **cycle counter**
 promising route to Home Assistant telemetry — it carries the counter and alarm
 state in plain ASCII, no radio decoding required.
 
-Everything below is recovered from `dumps/u2-mc9s08gt-flash.s19`; the bench steps
-are not yet done.
+Everything below is recovered from `dumps/u2-mc9s08gt-flash.s19` and **now
+confirmed on real hardware**: the fake-modem bench test reads live
+`CYCLE COUNTER` / `PLANT STATUS` / `ALARM STATUS` and the full config out of U2
+over the serial port (see "Validated on hardware" below).
 
 ## Firmware evidence
 
@@ -53,6 +55,64 @@ The stored placeholders are non-secret defaults (`PASS`, `+358000000000`).
 
 `CYCLE COUNTER:` is exactly the display's *satsräknare* — reaching it over the
 serial port is the goal of Path A.
+
+## Validated on hardware ✅
+
+The fake-modem test ([`tools/fake_telit.py`](../tools/fake_telit.py) `--sweep`)
+was run against U2 on **board A** and **works end to end** — no SIM, no network.
+U2 completes its full AT init against the fake modem, then answers an injected
+command SMS with plain-ASCII telemetry.
+
+**Command grammar (confirmed).** The SMS body is the unit's **4-character access
+code**, optionally followed by a sub-command. `CODE` in the firmware help is a
+*placeholder for that code*, **not** a literal keyword — bare `CODE` / `CODE CONF`
+drew **no reply**; only the real code (`PASS`) did:
+
+| SMS body      | reply |
+| ---           | ---   |
+| `PASS`        | plant status |
+| `PASS CONF`   | config settings |
+| `PASS CONF ?` | config help |
+| `PASS RS`     | reset to defaults (destructive — not run) |
+
+**Captured status (`PASS`), board A:**
+
+```
+CYCLE COUNTER:2129
+PLANT STATUS:S102
+ALARM STATUS:NO
+```
+
+**Captured config (`PASS CONF`), board A:**
+
+```
+CODE=PASS
+REPLY=ON
+HEARTBEAT=0
+SMSCOUNTER=1
+PHONE1=+358000000000
+PHONE2=+358000000000
+PHONE3=+358000000000
+```
+
+Notes:
+- Two EEPROM facts gate the reply, both now verified: U2 answers only a **stored
+  sender** (`PHONE1-3 = +358000000000`) and only when **`REPLY=ON`** (the `0x01`
+  byte at EEPROM `0x3A98`). `HEARTBEAT=0` means U2 sends nothing on its own — you
+  must poll it.
+- **`CYCLE COUNTER:2129` is board A's own counter**, not board B's display
+  *satsräknare* (1258); the two boards keep independent counts.
+- **`PLANT STATUS:S102`** is a status code, not yet mapped. Decode it like the
+  radio `[U6]`: read `PASS` at known display phases and tabulate the `S<nnn>`
+  values against the EEPROM cycle/phase table.
+- `ALARM STATUS` returns `NO` when clear; on a fault it carries the alarm text
+  (`Compressor fault`, `MV1`-`MV5 fault`, `EEPROM error`, …).
+
+**Home Assistant path.** Because `HEARTBEAT=0` and U2 replies only when polled,
+an HA integration is a persistent fake-modem daemon that injects `PASS` on a
+timer, parses the three status lines, and publishes them to MQTT (`cycle_counter`,
+`plant_status`, `alarm_status`). No SIM, no cellular, no radio decode — the most
+direct telemetry route found.
 
 ## Hardware access — J5 "Modem" header
 
@@ -124,23 +184,25 @@ side** (U2 SCI2 TX = the driver input pin), or an **RS-232-level** adapter on th
 J5 data pins. Prediction: a burst of printable ASCII — `ATE0`, `AT+CPIN?`,
 `AT+CREG?`… The pin that bursts is U2's transmit.
 
-**Tier 3 — fake modem, no SIM (strongest bench proof).** Cross-connect to the
-serial line — either an **RS-232 adapter on J5**, or (simpler) a plain USB-UART on
-the **SP3232 TTL side** (adapter **RX ← U2 SCI2 TX**, adapter **TX → U2 SCI2 RX**,
-common GND, **J5 5V pin left unconnected**) — and run
+**Tier 3 — fake modem, no SIM (done ✅ — see "Validated on hardware" above).**
+Cross-connect to the serial line — either an **RS-232 adapter on J5**, or
+(simpler) a plain USB-UART on the **SP3232 TTL side** (adapter **RX ← U2 SCI2 TX**,
+adapter **TX → U2 SCI2 RX**, common GND, **J5 5V pin left unconnected**) — and run
 [`tools/fake_telit.py`](../tools/fake_telit.py):
 
 ```
-python3 tools/fake_telit.py --port /dev/ttyUSB0
+python3 tools/fake_telit.py --port /dev/ttyUSB0 --sweep
 ```
 
 It answers U2's init handshake so U2 believes a registered modem is present, then
-**captures the SMS body U2 sends** (`AT+CMGS`) — which contains `CYCLE COUNTER:`,
-`PLANT STATUS:` and `ALARM STATUS:`. Press Enter to inject a fake incoming
-`CODE STATUS` SMS and exercise the query→reply path (`+CMTI` → `AT+CMGR`).
+**captures the SMS body U2 sends** (`AT+CMGS`) — `CYCLE COUNTER:`, `PLANT STATUS:`
+and `ALARM STATUS:`. `--sweep` auto-tries every candidate command; without it,
+press Enter to inject the `--inject` command (default `PASS`) and exercise the
+query→reply path (`+CMTI` → `AT+CMGR` → `AT+CMGS`). This yielded the captured
+telemetry above.
 
-**Tier 4 — full GSM (end-to-end).** Real SIM + antenna; text the unit its
-`CODE …` query and read the reply.
+**Tier 4 — full GSM (end-to-end, optional).** Real SIM + antenna; text the unit
+its `PASS` query and read the reply. Not needed now that tier 3 works.
 
-Recommended: **tier 2 → tier 3**. Tier 2 is a yes/no; tier 3 turns it into a
-working, SIM-free telemetry tap that already yields the cycle counter.
+Tier 3 is the payoff: a working, SIM-free telemetry tap that already yields the
+cycle counter, plant status, alarm state, and full config.


### PR DESCRIPTION
## Summary
The fake-modem `--sweep` run against U2 (board A) **works end to end, no SIM** — Path A is proven. This updates `docs/u2-serial-protocol.md` from "predicted" to "validated," with the captured data.

**Command grammar confirmed:** the SMS body is the unit's 4-character access code, optionally + `CONF` / `CONF ?` / `RS`. `CODE` in the firmware help is a *placeholder for the code*, not a literal keyword — bare `CODE` / `CODE CONF` drew **no reply**; only `PASS*` answered.

**Captured status (`PASS`), board A:**
```
CYCLE COUNTER:2129
PLANT STATUS:S102
ALARM STATUS:NO
```
**Captured config (`PASS CONF`):** `CODE=PASS`, `REPLY=ON`, `HEARTBEAT=0`, `SMSCOUNTER=1`, `PHONE1-3=+358000000000`

**Notes captured in the doc:**
- Both reply gates verified: stored sender (`PHONE1-3`) + `REPLY=ON` (the `0x01` at EEPROM `0x3A98`). `HEARTBEAT=0` → poll-only.
- `CYCLE COUNTER:2129` is **board A's** counter, not board B's display `1258` (two-boards split).
- `PLANT STATUS:S102` is the one remaining unknown — decode by reading `PASS` at known display phases.
- HA path: persistent fake-modem daemon polls `PASS` → parses 3 status lines → MQTT.

Marks verification tier 3 as done.

## Test plan
- [x] Bench: full run captured in `det.txt` (handshake + PASS/PASS CONF/PASS CONF ? all replied; literal CODE variants correctly got no reply).
- [ ] Follow-up: map `PLANT STATUS:S<nnn>` across phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)