### PR TITLE
rtl433 0d: trailer is CRC-16/CCITT (from firmware), not a proprietary check

### DIFF
--- a/docs/rtl433.md
+++ b/docs/rtl433.md
@@ -232,11 +232,24 @@ Across the whole 1.5 h log, all **136** response frames were byte-identical; eve
 bit of variation lived in the poll stream (30 distinct poll frames out of 594).
 So in normal idle only the poll side is worth diffing.
 
-### The 2-byte trailer is NOT a standard CRC `[U4]`
+### The 2-byte trailer IS a CRC-16/CCITT — over the *message*, not the on-air bytes `[U4]`
 
-Using a **differential** method — comparing frame-pair deltas, which cancels the
-constant header/marker bytes and is independent of the CRC `init`/`xorout` — the
-trailer (bytes 31–32) was tested against:
+**Update:** the trailer is now identified from the MC9S08 firmware — it is a
+plain **CRC-16/CCITT-FALSE** (poly `0x1021`, init `0xFFFF`, MSB-first, no
+reflection, no xorout, transmitted big-endian). The frame serializer `FUN_ce01`
+seeds the accumulator to `0xFFFF` (`FUN_e088`) and folds each byte in nibble-wise
+(`FUN_e0cd → FUN_e08e`) using two 16-entry tables at flash `0x8b14`/`0x8b24` that
+match the `0x1021` nibble table exactly.
+
+The differential search below did **not** find it — but that was a **domain**
+problem, not a nonlinear check. It ran over the **Manchester-decoded on-air
+bytes**; the CRC is computed over the MC9S08's **pre-encoding message bytes**,
+which are a *further-encoded* form on air. So the algorithm is fully known, but
+verifying it against a capture still needs the on-air↔message byte transform (the
+same open question as `[U5]`).
+
+The original (now-superseded) search, for the record — over the on-air bytes,
+trailer (bytes 31–32) tested against:
 
 - **CRC-16**: all **65536** polynomials × both byte-endiannesses × all
   reflection settings (refin/refout) × forward **and** reversed message-byte
@@ -244,12 +257,10 @@ trailer (bytes 31–32) was tested against:
 - **CRC-8** on each trailer byte independently → 0 matches.
 - **sum8, sum16, xor8, Fletcher-16, Adler** → 0 matches.
 
-Yet two idle frames that differ by only **one bit** (byte 27 `bc↔ac`, or byte 30
-`f6↔e6`) still produce different trailers, so it **is** a content-dependent check
-— just a **nonlinear / proprietary** one, not a bit-serial CRC. The de-whitening /
-bit-alignment question is therefore closed: the frame is already plaintext, so the
-remaining blocker is the check *function*, which likely needs the nRF9E5's 8051
-image (Path C) or many labelled captures to pin down.
+Two idle frames differing by only **one bit** (byte 27 `bc↔ac`, or byte 30
+`f6↔e6`) still produce different trailers — consistent with a CRC over a
+transformed message. The remaining blocker is the on-air↔message mapping, not the
+check function.
 
 **Practical upshot:** we do **not** need the trailer to read telemetry. The
 payload is plaintext, so fields can be mapped purely by correlating byte changes


### PR DESCRIPTION
## Summary
Corrects the "0d" conclusion in `docs/rtl433.md`. Decompiling the MC9S08 frame serializer (`FUN_ce01`) settles the 2-byte payload trailer that the earlier exhaustive search couldn't match: it's a plain **CRC-16/CCITT-FALSE**.

- **poly `0x1021`, init `0xFFFF`, MSB-first, no reflection, no xorout, big-endian**
- Computed nibble-wise (`FUN_e0cd → FUN_e08e`) using two 16-entry tables at flash `0x8b14`/`0x8b24` that match the `0x1021` nibble table exactly.
- The "0d" search found **0 matches** only because it ran over the **Manchester-decoded on-air bytes**; the CRC covers the MC9S08's **pre-encoding message bytes** (a further-encoded form on air). A **domain** problem, not a nonlinear check.

So the algorithm is fully known; verifying it against a capture still needs the on-air↔message byte transform (the same open `[U5]`).

## Reviewer notes
- Doc-only change to the "0d" section of `docs/rtl433.md`.
- Firmware detail sits in [PR #76](https://github.com/andy778/UClean1/pull/76) (nRF9E5 8051 extraction/analysis), still open — this PR only fixes the stale `[U4]` conclusion on `main`.
- Also reflected in the rtl_433 decoder header comment on `andy778/rtl_433@add-uponor-clean1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)