### PR TITLE
docs/ghidra: add radio/CRC/alarm decompiles + decode the payload body

### DIFF
--- a/docs/ghidra/README.md
+++ b/docs/ghidra/README.md
@@ -1,0 +1,94 @@
+# Ghidra decompiles — U2 firmware
+
+Raw Ghidra output for the U2 (MC9S08GT) functions we relied on, kept here so the
+reasoning is checkable against the binary. Extracted from
+[`dumps/u2-mc9s08gt-flash.bin`](../../dumps/u2-mc9s08gt-flash.bin) with the
+scripts in [`tools/ghidra/`](../../tools/ghidra). Addresses are the RAM/flash
+addresses Ghidra shows (`file_offset + 0x107f`).
+
+| File | What it covers |
+| --- | --- |
+| [`radio_frame.c`](radio_frame.c) | Builds the 32-byte nRF905 payload + CRC (`FUN_db22` → `FUN_ced9` → `FUN_ce01`). |
+| [`crc16.c`](crc16.c) | The CRC-16 update (`FUN_e0cd`/`FUN_e08e`, tables `0x8b14`/`0x8b24`). |
+| [`alarm_frames.c`](alarm_frames.c) | The 5 alarm/status message types → the 5 infopanel symbols (`FUN_e372`/`e427`/`e0e5`). |
+| [`eeprom_i2c.c`](eeprom_i2c.c), [`periph_init.c`](periph_init.c) | I2C EEPROM access and peripheral bring-up. |
+
+## What the radio payload is
+
+The link carries the indoor **infopanel** state, not analog telemetry. Each frame
+is one message with a 1-byte **type** and a boolean **state**; there are exactly
+5 types, one per panel symbol. Full frame = `4-byte address` + `32-byte payload`
++ `2-byte CRC`, transmitted MSB-first.
+
+### 32-byte payload byte map (verified byte-exact, incl. a reboot capture)
+
+| Byte | Source in firmware | Meaning |
+| --- | --- | --- |
+| 0 | `record[8] + record[0xb] + 12` = `12 + N` | header; `N` = message length |
+| 1 | const | `0xCC` |
+| 2 | const | `0x6E` |
+| 3 | `((record[8]&3)<<4) \| record[9] \| 0x0f` | flags + **direction** (`record[9]`: `0x40` poll / `0x80` response) |
+| 4 | RAM `0x013e` lo | correlation word 1 |
+| 5–6 | RAM `0x0140` | correlation word 2 |
+| 7 | RAM `0x0109` lo | correlation word 3 |
+| 8–9 | RAM `0x010b` | correlation word 4 |
+| 10 | `record[0xb]` | **`N` = message-body length** |
+| 11 … 10+N | `&DAT_06be` | the `N` message bytes |
+| 11+N … 31 | — | **stale buffer, not data** |
+
+The four correlation words are a poll/ack cookie: the **response** frame carries
+the same fields with the direction bit set to `0x80` and the ID pairs swapped
+(an ACK handshake). See [`radio_frame.c`](radio_frame.c) `FUN_db22`.
+
+### Message body — the `N` bytes at `payload[11]`
+
+`payload[10] = N` and `hdr0 = 12 + N` cross-check. Confirmed on three frame
+types from one reboot capture (pull external unit power ~10 s, plug back in):
+
+| Frame | hdr0 | N | body | Meaning |
+| --- | --- | --- | --- | --- |
+| response | `0x0c` | 0 | *(none)* | ACK, no body |
+| poll | `0x0d` | 1 | `24` | heartbeat opcode |
+| **alarm** | `0x0e` | 2 | `20 00` | `[type=0x20 status, state=0 OK]` |
+
+Alarm body = `[type, state]`; `state` 0/1 = clear/active. Only type `0x20`
+(status / green LED idle) has been captured so far — the other four
+(`0x21`/`0x22`/`0x23`/`0x26`) need a capture **started before power-on** to catch
+the boot burst. See [`alarm_frames.c`](alarm_frames.c).
+
+**Bytes `11+N … 31` are stale buffer, not data.** U2 fills only `N` body bytes
+and radios the leftover buffer, so identical logical frames print different
+tails run-to-run — the CRC still passes because U2 computes it over whatever it
+sends. Decode nothing past `payload[10] + N`.
+
+### Trailer = CRC-16/CCITT-FALSE
+
+Seed `0xFFFF` (`FUN_e088`), poly `0x1021`, no reflection, xorout 0, over
+`address + payload`. Confirmed on-air by
+[`tools/rtl433/probe_capture.py`](../../tools/rtl433/probe_capture.py) and by the
+`crc16()` gate in the rtl_433 decoder. See [`crc16.c`](crc16.c).
+
+### The 5 message types → panel symbols
+
+| Type | Live source | Alarm code(s) | Panel symbol |
+| --- | --- | --- | --- |
+| `0x20` | `DAT_0757` | `0x02` (E011) | status / OK LED |
+| `0x21` | `DAT_06ff` | `0x15` (E021) | chemical level low |
+| `0x22` | `DAT_0707/070f/075b` + array | `0x1F`/`0x20` (E03x) | high water |
+| `0x23` | `DAT_074f` | `0x33` (E051) | sludge-empty reminder |
+| `0x26` | `DAT_0747` + array `0x0717..` | `0x2F`, `0x28–0x2D` | device fault `!` |
+
+Codes → display E-codes are decoded in [`../eeprom-map.md`](../eeprom-map.md).
+
+## Open item for the next capture
+
+The `[type, state]` offset is now pinned (type = `payload[11]`, state =
+`payload[12]`), and the rtl_433 decoder emits `msg_len`/`msg_type`/`msg_name`/
+`msg_state`. Only the `0x20` (status) type has been seen on air so far.
+
+Alarm messages are **edge-driven** (`FUN_e0e5`) or fire in the boot burst
+(`FUN_e372`), so a capture started *after* boot shows only the heartbeat frames
+plus the repeating status. To catch all five types (`0x20`/`0x21`/`0x22`/`0x23`/
+`0x26`), **start `rtl_433` first, then power the unit on** — that confirms the
+`msg_name` mapping for the remaining four symbols (chemical_low / high_water /
+sludge_reminder / device_fault). See [`../rtl433-decoder.md`](../rtl433-decoder.md).

--- a/docs/ghidra/alarm_frames.c
+++ b/docs/ghidra/alarm_frames.c
@@ -1,0 +1,191 @@
+/*
+ * MC9S08GT (U2) — alarm/status TX, Ghidra decompile (raw, lightly annotated).
+ *
+ * The radio receiver is the indoor infopanel: 5 alarm symbols + one OK button
+ * + a green/red LED. Each radio message carries a TYPE byte and a boolean state.
+ * There are exactly 5 message types -> the 5 panel symbols:
+ *
+ *   type  RAM source(s)                 alarm code(s)     panel meaning
+ *   0x20  DAT_0757                       0x02 (E011)       status / OK LED
+ *   0x21  DAT_06ff                       0x15 (E021)       chemical level low
+ *   0x22  DAT_0707/070f/075b + array     0x1F/0x20 (E03x)  high water
+ *   0x23  DAT_074f                       0x33 (E051)       sludge-empty reminder
+ *   0x26  DAT_0747 + array 0x0717..      0x2F,0x28-0x2D    device fault "!"
+ *
+ * FUN_e372 = reset/all-clear: sends all 5 types with state 0 at boot.
+ * FUN_e427 = periodic: sends each type with its live boolean.
+ * FUN_e0e5 = event-driven: sends a type ONLY when its state changed (edge).
+ *
+ * Alarm codes -> E-codes are in docs/eeprom-map.md. Because live alarms are
+ * edge-driven (FUN_e0e5), an idle capture shows only the two heartbeat frames;
+ * to see the 5 alarm frames, power-cycle the styrskap during capture (FUN_e372).
+ */
+
+/* ---- FUN_e372 @ e372 : reset -> emit all 5 symbols as "clear" -------------- */
+void FUN_e372(char param_1)
+{
+  undefined1 extraout_HI, extraout_HI_00, extraout_HI_01, extraout_HI_02;
+  char in_X;
+  byte bVar2;
+  ushort uVar1;
+  byte bStack_2;
+
+  if (param_1 == '\0') _DAT_0134 = (ushort)(DAT_0135 & 0x40);
+  else                 _DAT_0134 = 0;
+
+  bStack_2 = 0;                         /* clear the 12-entry x 8-byte alarm table @06f7 */
+  do {
+    bVar2 = bStack_2 << 3;
+    uVar1 = (ushort)bVar2;
+    (&DAT_06f7)[uVar1] = 0;
+    *(undefined1 *)(uVar1 + 0x6f8) = 0;
+    *(undefined1 *)(uVar1 + 0x6f9) = 0;
+    if (in_X != '\0') {
+      FUN_a66e(0,(char)((ushort)*(undefined2 *)(&DAT_06fc + uVar1) >> 8),
+               (char)*(undefined2 *)(&DAT_06fc + uVar1));
+      *(undefined1 *)(bVar2 + 0x6fb) = 0;
+      *(undefined1 *)(bVar2 + 0x6fa) = 0;
+    }
+    bStack_2 = bStack_2 + 1;
+  } while (bStack_2 < 0xc);
+
+  bStack_2 = 0;                         /* clear the 2 x status slots @0757 */
+  do {
+    uVar1 = (ushort)(byte)(bStack_2 << 2);
+    (&DAT_0757)[uVar1] = 0;
+    (&DAT_0758)[uVar1] = 0;
+    *(undefined1 *)(uVar1 + 0x759) = 0;
+    bStack_2 = bStack_2 + 1;
+  } while (bStack_2 < 2);
+
+  if ((_DAT_0134 & 0x40) != 0) DAT_0747 = 0x2f;   /* EEPROM/program fault seed */
+  if (_DAT_0134 == 0) { FUN_a334(); FUN_a1d3(); }
+  DAT_060f = 0; DAT_0610 = 0; DAT_0611 = 0; DAT_0612 = 0;
+
+  FUN_db22(0x20);                                        /* status / OK LED     */
+  FUN_db22(0,CONCAT11(extraout_HI,   0x21));             /* chemical low        */
+  FUN_db22(0,CONCAT11(extraout_HI_00,0x22));             /* high water          */
+  FUN_db22(0,CONCAT11(extraout_HI_01,0x23));             /* sludge reminder     */
+  FUN_db22(0,CONCAT11(extraout_HI_02,0x26));             /* device fault "!"    */
+  return;
+}
+
+/* ---- FUN_e427 @ e427 : periodic -> emit all 5 with their live booleans ----- */
+void FUN_e427(void)
+{
+  bool bVar1;
+  char cVar2;
+  undefined1 uVar3;
+  char cStack_2;
+  byte bStack_1;
+
+  bVar1 = false;
+  cStack_2 = '\0';
+  cVar2 = FUN_de1b((char)((ushort)_DAT_013e >> 8),(char)_DAT_013e,
+                   (char)((ushort)_DAT_0140 >> 8),(char)_DAT_0140);
+  if (cVar2 != '\0') {
+    FUN_db22(DAT_0757 != '\0');                          /* 0x20 status         */
+    FUN_db22(DAT_06ff != '\0');                          /* 0x21 chemical low   */
+    if (DAT_0707 != '\0') cStack_2 = '\x01';
+    if (DAT_070f != '\0') cStack_2 = '\x01';
+    if ((DAT_075b == '\0') && (cStack_2 == '\0')) uVar3 = 0; else uVar3 = 1;
+    FUN_db22(uVar3);                                     /* 0x22 high water     */
+    FUN_db22(DAT_074f != '\0');                          /* 0x23 sludge remind  */
+    bStack_1 = 0;                                        /* scan MV/compressor  */
+    do {
+      if (*(char *)((byte)(bStack_1 << 3) + 0x717) != '\0') bVar1 = true;
+      bStack_1 = bStack_1 + 1;
+    } while (bStack_1 < 6);
+    if ((DAT_0747 != '\0') || (bVar1)) uVar3 = 1; else uVar3 = 0;
+    FUN_db22(uVar3,CONCAT11((char)((ushort)&cStack_2 >> 8),0x22));   /* 0x26 fault */
+  }
+  return;
+}
+
+/* ---- FUN_e0e5 @ e0e5 : edge-driven -> emit a type only when its state moved  */
+/* Each block compares a "last-sent" shadow (0758/0700/06f8.../075c/0750/0748)   */
+/* against the live value; on a change it updates the shadow and calls FUN_db22  */
+/* with the new boolean. This is why alarms are NOT in the idle heartbeat.       */
+void FUN_e0e5(char param_1,char param_2)
+{
+  bool bVar1;
+  undefined1 *puVar2;
+  char *pcVar3;
+  char cVar5;
+  byte extraout_X, extraout_X_00, extraout_X_01;
+  short sVar4;
+  byte bVar6, unaff_retaddr, unaff_retaddr_00, bVar7;
+  undefined1 auStack_3 [3];
+
+  if (_DAT_0134 == 0) FUN_a334(); else FUN_a32f();
+  puVar2 = (undefined1 *)FUN_9da6();
+  if ((DAT_00ff & 1) != 0) *puVar2 = (char)puVar2;
+  *puVar2 = (char)puVar2;
+  pcVar3 = (char *)FUN_9df0(auStack_3);
+  cVar5 = (char)pcVar3;
+  if ((DAT_00ff & 1) != 0) *pcVar3 = cVar5;
+  *pcVar3 = cVar5;
+  if (cVar5 == '\0') { bVar7 = 2; }
+  else {
+    bVar7 = (((DAT_0141 == '\0' && DAT_0140 == '\0') && DAT_013f == '\0') && DAT_013e == '\0') << 1;
+    if (((DAT_0141 != '\0' || DAT_0140 != '\0') || DAT_013f != '\0') || DAT_013e != '\0') {
+      if (DAT_013d != '\0') {
+        bVar7 = (DAT_0758 == DAT_0757) << 1;                     /* 0x20 status  */
+        if ((DAT_0758 != DAT_0757) && (FUN_e26f(), (bVar7 >> 1 & 1) != 1)) {
+          DAT_0758 = DAT_0757; FUN_db22(DAT_0757 != '\0'); }
+        bVar7 = (DAT_0700 == DAT_06ff) << 1;                     /* 0x21 chem    */
+        if ((DAT_0700 != DAT_06ff) && (FUN_e26f(), (bVar7 >> 1 & 1) != 1)) {
+          DAT_0700 = DAT_06ff; FUN_db22(DAT_06ff != '\0'); }
+        bVar7 = 2;
+        do {                                                     /* high-water array */
+          FUN_e280();
+          bVar1 = *(char *)(extraout_X + 0x6f8) == (&DAT_06f7)[extraout_X];
+          bVar6 = bVar1 << 1;
+          if ((!bVar1) && (FUN_e26f(), (bVar6 >> 1 & 1) != 1))
+            *(undefined1 *)(extraout_X + 0x6f8) = (&DAT_06f7)[extraout_X];
+          FUN_e280();
+          if ((&DAT_06f7)[extraout_X_00] != '\0') param_2 = '\x01';
+          bVar7 = bVar7 + 1;
+        } while (bVar7 < 4);
+        bVar7 = (DAT_075c == DAT_075b) << 1;
+        if ((DAT_075c != DAT_075b) && (FUN_e26f(), (bVar7 >> 1 & 1) != 1)) DAT_075c = DAT_075b;
+        if (DAT_075b != '\0') param_2 = '\x01';
+        bVar7 = (DAT_0149 == param_2) << 1;                      /* 0x22 high water */
+        if ((DAT_0149 != param_2) && (FUN_e26f(), (bVar7 >> 1 & 1) != 1)) {
+          DAT_0149 = param_2; FUN_db22(param_2 != '\0'); }
+        bVar7 = (DAT_0750 == DAT_074f) << 1;                     /* 0x23 sludge  */
+        if ((DAT_0750 != DAT_074f) && (FUN_e26f(), (bVar7 >> 1 & 1) != 1)) {
+          DAT_0750 = DAT_074f; FUN_db22(DAT_074f != '\0'); }
+        unaff_retaddr_00 = 0;
+        goto LAB_e206;
+      }
+      bVar7 = 2;
+    }
+  }
+  do {
+    if ((bVar7 >> 1 & 1) == 1) return;
+    *(undefined1 *)(unaff_retaddr + 0x718) = *(undefined1 *)(unaff_retaddr + 0x717);
+    do {
+      sVar4 = FUN_e280();
+      if (*(char *)(sVar4 + 0x717) != '\0') param_1 = '\x01';
+      unaff_retaddr_00 = unaff_retaddr_00 + 1;
+      if (5 < unaff_retaddr_00) {                                /* 0x26 device fault */
+        if (DAT_0748 != DAT_0747) DAT_0748 = DAT_0747;
+        if (DAT_0747 != '\0') param_1 = '\x01';
+        bVar7 = (DAT_0148 == param_1) << 1;
+        if (DAT_0148 == param_1) return;
+        FUN_e26f();
+        if ((bVar7 >> 1 & 1) == 1) return;
+        DAT_0148 = param_1;
+        FUN_db22(param_1 != '\0',CONCAT11((char)((ushort)&stack0x0001 >> 8),0x22));
+        return;
+      }
+LAB_e206:
+      FUN_e280();
+      bVar1 = *(char *)(extraout_X_01 + 0x718) == *(char *)(extraout_X_01 + 0x717);
+      bVar7 = bVar1 << 1;
+    } while (bVar1);
+    FUN_e26f();
+    unaff_retaddr = extraout_X_01;
+  } while( true );
+}

--- a/docs/ghidra/crc16.c
+++ b/docs/ghidra/crc16.c
@@ -1,0 +1,66 @@
+/*
+ * MC9S08GT (U2) — CRC-16 update, Ghidra disassembly (raw).
+ *
+ * FUN_e0cd folds one BYTE into the running CRC by processing its two nibbles
+ * through FUN_e08e. FUN_e08e is a nibble-indexed table update using two 16-entry
+ * tables at flash 0x8b14 (hi) and 0x8b24 (lo). Combined with the 0xFFFF seed
+ * (FUN_e088) and MSB-first byte order, this reproduces CRC-16/CCITT-FALSE
+ * (poly 0x1021, init 0xFFFF, no reflect, xorout 0) — confirmed on-air by
+ * tools/rtl433/probe_capture.py and by the rtl_433 decoder's crc16() gate.
+ *
+ * This is why the rtl_433 decoder calls the field "mic" (Message Integrity
+ * Check) — it is the frame's CRC.
+ */
+
+/* ---- FUN_e0cd : update CRC with one byte (high nibble then low nibble) ----- */
+e0cd  PSHA
+e0ce  AIS #-0x2
+e0d0  STHX 0x1,SP
+e0d3  NSA            ; swap nibbles
+e0d4  AND #0xf
+e0d6  BSR 0xe08e     ; fold high nibble
+e0d8  LDHX 0x1,SP
+e0db  LDA 0x3,SP
+e0de  AND #0xf
+e0e0  BSR 0xe08e     ; fold low nibble
+e0e2  AIS #0x3
+e0e4  RTS
+
+/* ---- FUN_e08e : fold one nibble via the 256->16 CRC tables ----------------- */
+e08e  PSHX
+e08f  PSHH
+e090  PSHA
+e091  LDA ,X
+e092  PSHA
+e093  NSA
+e094  AND #0xf
+e096  EOR 0x2,SP
+e099  PSHA
+e09a  LDA 0x2,SP
+e09d  NSA
+e09e  AND #0xf0
+e0a0  STA 0x2,SP
+e0a3  LDA 0x1,X
+e0a5  NSA
+e0a6  AND #0xf
+e0a8  ORA 0x2,SP
+e0ab  STA ,X
+e0ac  LDA 0x1,X
+e0ae  NSA
+e0af  AND #0xf0
+e0b1  STA 0x1,X
+e0b3  LDA ,X
+e0b4  TSX
+e0b5  LDX ,X
+e0b6  CLRH
+e0b7  EOR 0x8b14,X   ; CRC table (hi byte)
+e0ba  LDHX 0x4,SP
+e0bd  STA ,X
+e0be  LDA 0x1,X
+e0c0  PULX
+e0c1  CLRH
+e0c2  EOR 0x8b24,X   ; CRC table (lo byte)
+e0c5  LDHX 0x3,SP
+e0c8  STA 0x1,X
+e0ca  AIS #0x4
+e0cc  RTS

--- a/docs/ghidra/radio_frame.c
+++ b/docs/ghidra/radio_frame.c
@@ -1,0 +1,133 @@
+/*
+ * MC9S08GT (U2) — radio TX path, Ghidra decompile (raw, lightly annotated).
+ *
+ * Source: dumps/u2-mc9s08gt-flash.bin. Addresses are RAM/flash addresses shown
+ * by Ghidra (file_offset + 0x107f). These are the functions that BUILD the
+ * 32-byte nRF905 payload and its CRC. The nRF9E5 (U1) 8051 is only a relay —
+ * see docs/nrf9e5-firmware.md — so all payload semantics live here.
+ *
+ * Call chain for one radio message:
+ *   FUN_db22(type)  -> snapshots the correlation words + direction, then
+ *   FUN_ced9(...)   -> assembles the frame, then
+ *   FUN_ce01(...)   -> serialises bytes and runs the CRC, then
+ *   FUN_e0cd/e08e   -> CRC-16/CCITT-FALSE nibble update (tables 0x8b14 / 0x8b24).
+ *
+ * See docs/rtl433-decoder.md for the resulting on-air byte map.
+ */
+
+/* ---- FUN_db22 @ db22 : queue one radio message of a given "type" ---------- */
+/* Snapshots the four poll/ack correlation words (013e,0140,0109,010b) and the  */
+/* direction/marker bytes, stores the message TYPE in DAT_06be/06bf, then calls */
+/* the assembler FUN_ced9. local_6 = 0x40 is the direction marker (poll).       */
+void FUN_db22(undefined1 param_1)   /* param_1 = message type (0x20..0x26) */
+{
+  char cVar1;
+  undefined1 in_X;
+  undefined2 local_f;
+  undefined2 local_d;
+  undefined2 local_b;
+  undefined2 local_9;
+  undefined1 uStack_7;
+  undefined1 local_6;
+  undefined1 local_4;
+  undefined1 *local_2;
+
+  if (DAT_06e9 != '\0') {          /* radio enabled */
+    local_d = _DAT_0140;           /* correlation word 2 -> payload[5:7] */
+    local_f = _DAT_013e;           /* correlation word 1 -> payload[4]   */
+    local_9 = _DAT_010b;           /* correlation word 4 -> payload[8:10]*/
+    local_b = _DAT_0109;           /* correlation word 3 -> payload[7]   */
+    uStack_7 = 0;
+    local_6 = 0x40;                /* direction marker: 0x40 = poll */
+    local_4 = 2;
+    local_2 = &DAT_06be;
+    DAT_06be = in_X;               /* type high byte */
+    DAT_06bf = param_1;            /* type          */
+    FUN_ced9(&local_f);
+    FUN_8fc4(0,0,0,0,0x1e,8);
+    while( true ) {
+      cVar1 = FUN_9120();
+      if (cVar1 != '\0') break;
+      SRS = 0;
+    }
+  }
+  return;
+}
+
+/* ---- FUN_ced9 @ ced9 : assemble the frame into the SPI-out buffer ---------- */
+/* Copies fields with FUN_9fc9(memcpy), sets the CRC anchor (066b=0x66d), calls  */
+/* FUN_ce01 to serialise+CRC, FUN_8eb2 kicks the SCI/SPI transmitter. When the   */
+/* direction byte at +9 == '@' (0x40, a poll) it also arms the ack-wait timer.   */
+void FUN_ced9(undefined2 param_1)
+{
+  undefined1 uVar1, uVar2, in_stack_00000000, uStack_1;
+
+  uVar2 = (undefined1)((ushort)param_1 >> 8);
+  _uStack_1 = CONCAT11(uVar2,in_stack_00000000);
+  while (DAT_064d != '\0') { uVar1 = FUN_d02f(); SRS = uVar1; }
+  FUN_9fc9(uVar2,in_stack_00000000,6,0x5e,_uStack_1);
+  FUN_9fc9((char)((ushort)*(undefined2 *)(_uStack_1 + 0xd) >> 8),
+           (char)*(undefined2 *)(_uStack_1 + 0xd),6,0x6d);
+  _DAT_066b = 0x66d;
+  FUN_ce01();
+  FUN_8eb2();
+  if (*(char *)(_uStack_1 + 9) == '@') {   /* 0x40 poll -> expect a response */
+    DAT_064e = 0;
+    FUN_8fc4(1,&UNK_cf94,0,3,0xe8,9);
+    DAT_068b = 1;
+    DAT_064d = '\x01';
+  }
+  return;
+}
+
+/* ---- FUN_ce01 @ ce01 : serialise payload bytes + running CRC --------------- */
+/* uStack_8/uStack_7 = the CRC accumulator, seeded to 0xFFFF by FUN_e088.        */
+/* cStack_3 = payload[0] = record[8] + record[0xb] + 12.                         */
+/* bStack_2 = payload[3] = ((record[8]&3)<<4) | record[9] | 0x0f  (record[9] is  */
+/*            the direction: 0x40 poll / 0x80 response).                         */
+/* FUN_8ec7 = push one byte to the SCI/SPI FIFO; FUN_cec7/ceb8/cec1 = push byte  */
+/* AND fold it into the CRC. The two trailing FUN_8ec7(uStack_8/uStack_7) append */
+/* the 16-bit CRC, MSB first.                                                    */
+void FUN_ce01(undefined2 param_1)
+{
+  undefined1 in_stack_00000000;
+  undefined1 local_b [3];
+  undefined1 uStack_8;   /* CRC hi */
+  undefined1 uStack_7;   /* CRC lo */
+  byte local_6;
+  undefined1 uStack_5, uStack_4;
+  char cStack_3;         /* payload[0] */
+  byte bStack_2;         /* payload[3] */
+  undefined1 uStack_1;
+
+  _uStack_1 = CONCAT11((char)((ushort)param_1 >> 8),in_stack_00000000);
+  uStack_4 = 0;
+  uStack_5 = 0;
+  FUN_e088(&uStack_8);                 /* CRC = 0xFFFF */
+  cStack_3 = *(char *)(_uStack_1 + 8) + *(char *)(_uStack_1 + 0xb) + '\f';
+  FUN_8ec7();                          /* payload[1] = 0xCC (const, from caller) */
+  FUN_8ec7();                          /* payload[2] = 0x6E (const)              */
+  FUN_cec7(&uStack_8);                 /* payload[0] = cStack_3, +CRC            */
+  bStack_2 = (*(byte *)(_uStack_1 + 8) & 3) << 4 | *(byte *)(_uStack_1 + 9) | 0xf;
+  FUN_cec7(&uStack_8);                 /* payload[3] = bStack_2, +CRC            */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[4]  = word_013e lo            */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[5]                            */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[6]  = word_0140              */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[7]  = word_0109 lo           */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[8]                            */
+  FUN_ceb8(local_b); FUN_cec1();       /* payload[9]  = word_010b              */
+  if (*(char *)(_uStack_1 + 8) != '\0') { FUN_ceb8(local_b); FUN_cec1(); }
+  FUN_ceb8(local_b); FUN_cec1();
+  local_6 = 0;
+  while( true ) {                      /* variable tail: record[0xb] more bytes */
+    if (*(byte *)(_uStack_1 + 0xb) <= local_6) break;
+    FUN_ceb8(local_b); FUN_cec1();
+    local_6 = local_6 + 1;
+  }
+  FUN_8ec7(uStack_8);                  /* CRC hi (payload trailer byte 0) */
+  FUN_8ec7(uStack_7);                  /* CRC lo (payload trailer byte 1) */
+  return;
+}
+
+/* ---- FUN_e088 @ e088 : seed the CRC accumulator to 0xFFFF ------------------ */
+void FUN_e088(undefined1 *param_1) { *param_1 = 0xff; param_1[1] = 0xff; return; }


### PR DESCRIPTION
Commits the U2 (MC9S08GT) Ghidra decompiles behind the radio conclusions, and folds in the reboot-capture finding that cracks the message body.

## Files
- `docs/ghidra/radio_frame.c` — `FUN_db22/ced9/ce01`, the 32-byte payload + CRC assembly
- `docs/ghidra/crc16.c` — `FUN_e0cd/e08e`, CRC-16/CCITT-FALSE nibble update (tables `0x8b14`/`0x8b24`)
- `docs/ghidra/alarm_frames.c` — `FUN_e372/e427/e0e5`, the 5 message types → 5 info-panel symbols
- `docs/ghidra/README.md` — payload byte map, CRC, type→symbol table, next-capture note

## Key result (from a reboot capture: pull external-unit power ~10 s, replug)
`payload[10] = N` (message-body length) and `hdr0 = 12 + N`. `N` body bytes follow at `payload[11]`; bytes `11+N…31` are stale buffer (identical logical frames print different tails; CRC still passes because U2 CRCs whatever it sends).

Alarm body = `[type, state]`. Captured the `0x20` status/OK-LED frame (`hdr0=0x0e`, body `20 00` = green LED, no faults). response N=0, poll N=1 (heartbeat opcode `0x24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)